### PR TITLE
sdk/src/cameras/itof-camera: read fw multiple times

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -869,16 +869,24 @@ aditof::Status CameraItof::readSerialNumber(std::string &serialNumber,
 }
 
 aditof::Status CameraItof::saveModuleCCB(const std::string &filepath) {
+    aditof::Status status =
+        aditof::Status::GENERIC_ERROR; //Defining with error for ccb read
+
     if (filepath.empty()) {
         LOG(ERROR) << "File path where CCB should be written is empty.";
         return aditof::Status::INVALID_ARGUMENT;
     }
 
     std::string ccbContent;
-    aditof::Status status = readAdsd3500CCB(ccbContent);
+    for (int i = 0; (i < NR_READADSD3500CCB && status != aditof::Status::OK);
+         i++) {
+        LOG(INFO) << "readAdsd3500CCB read attempt nr :" << i;
+        status = readAdsd3500CCB(ccbContent);
+    }
 
     if (status != aditof::Status::OK) {
-        LOG(ERROR) << "Failed to read CCB from adsd3500 module!";
+        LOG(ERROR) << "Failed to read CCB from adsd3500 module after "
+                   << NR_READADSD3500CCB << " reads!";
         return aditof::Status::GENERIC_ERROR;
     }
 

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -41,6 +41,8 @@
 #include <map>
 #include <unordered_map>
 
+#define NR_READADSD3500CCB 3
+
 class CameraItof : public aditof::Camera {
   public:
     CameraItof(std::shared_ptr<aditof::DepthSensorInterface> depthSensor,


### PR DESCRIPTION
Since firmware read can include corrupted data it is more stable to try reading it multiple timesm until sucesfully completing the task.