### PR TITLE
Extending compatibility to ROS2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!-- This file is used to build libaditof as a ROS package -->
-<package format="2">
+<package format="3">
   <name>libaditof</name>
   <version>1.0.0</version>
   <description>The ADI ToF SDK ROS package</description>
@@ -9,9 +9,12 @@
   <url type="website">https://github.com/analogdevicesinc/libaditof</url>
   <license>MIT</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>  
-  <build_export_depend>roscpp</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>  
+  <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
+
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+  <depend condition="$ROS_VERSION == 2">rclcpp</depend>
 
 </package>


### PR DESCRIPTION
The currently existing `package.xml` file is not supported when using the package in ROS2 environment. I have proposed some modifications to allow libaditof to be built, both in ROS1 and ROS2.