### PR TITLE
Isolated Build Fix for ROS Buildfarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Other
 ## Supported Embedded Platforms
 
 For more details on building the SDK on an embedded platform please check the **User Guide** specified below:
+
 ### ITOF camera
+
 | Operating system | Evaluation boards | Documentation | GitHub main status |
 | --------- | ----------- | ----------- | ----------- |
 | NXP | [EVAL-ADTF3175D-NXZ](https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175d-nxz) | [Build instructions](doc/itof/nxp_build_instructions.md) | [![Build status](https://dev.azure.com/AnalogDevices/3DToF-rework/_apis/build/status/analogdevicesinc.ToF?branchName=main)](https://dev.azure.com/AnalogDevices/3DToF-rework/_build?view=runs&branchFilter=3310) |
@@ -51,9 +53,11 @@ For more details about the SDK check the links below:
 [Building and installing the SDK](cmake)
 
 ## SDK Examples
+
 The list of examples can be found at [this link.](https://github.com/analogdevicesinc/ToF?tab=readme-ov-file#sdk-examples)
 
 ## Directory Structure
+
 | Directory | Description |
 | --------- | ----------- |
 | ci | Useful scripts for continuous integration |

--- a/package.xml
+++ b/package.xml
@@ -16,5 +16,8 @@
 
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
 
 </package>


### PR DESCRIPTION
This commit fixes the error raised by the ROS [build farm](https://build.ros.org/job/Ndev__libaditof__ubuntu_focal_amd64/1/console). The proposed changes in `package.xml` identifies this package as a non-catkin package.