### PR TITLE
Multi thread approach in buffer_processor

### DIFF
--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -727,7 +727,7 @@ Adsd3500Sensor::setMode(const aditof::DepthSensorModeDetails &type) {
     if (!type.isPCM) {
         //TO DO: update this values when frame_impl gets restructured
         status = m_bufferProcessor->setVideoProperties(
-            type.baseResolutionWidth * 4, type.baseResolutionHeight);
+            type.baseResolutionWidth, type.baseResolutionHeight);
         if (status != Status::OK) {
             LOG(ERROR) << "Failed to set bufferProcessor properties!";
             return status;

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -727,7 +727,8 @@ Adsd3500Sensor::setMode(const aditof::DepthSensorModeDetails &type) {
     if (!type.isPCM) {
         //TO DO: update this values when frame_impl gets restructured
         status = m_bufferProcessor->setVideoProperties(
-            type.baseResolutionWidth, type.baseResolutionHeight);
+            type.baseResolutionWidth, type.baseResolutionHeight,
+            type.frameWidthInBytes, type.frameHeightInBytes);
         if (status != Status::OK) {
             LOG(ERROR) << "Failed to set bufferProcessor properties!";
             return status;

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -433,6 +433,7 @@ aditof::Status Adsd3500Sensor::stop() {
     Status status = Status::OK;
     struct VideoDev *dev;
 
+    m_bufferProcessor->stopThreads();
     for (unsigned int i = 0; i < m_implData->numVideoDevs; i++) {
         dev = &m_implData->videoDevs[i];
 
@@ -450,7 +451,6 @@ aditof::Status Adsd3500Sensor::stop() {
 
         dev->started = false;
     }
-    m_bufferProcessor->stopThreads();
 
     return status;
 }

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -423,6 +423,7 @@ aditof::Status Adsd3500Sensor::start() {
 
         dev->started = true;
     }
+    m_bufferProcessor->startThreads();
 
     return status;
 }
@@ -449,6 +450,8 @@ aditof::Status Adsd3500Sensor::stop() {
 
         dev->started = false;
     }
+    m_bufferProcessor->stopThreads();
+
     return status;
 }
 

--- a/sdk/src/connections/target/buffer_processor.cpp
+++ b/sdk/src/connections/target/buffer_processor.cpp
@@ -137,6 +137,8 @@ aditof::Status BufferProcessor::setVideoProperties(int frameWidth,
     m_outputFrameWidth = frameWidth;
     m_outputFrameHeight = frameHeight;
 
+    LOG(INFO) << __func__ << ": Width : " << m_outputFrameWidth << " Height: " << m_outputFrameHeight;
+
     //m_videoFormat.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
     //m_videoFormat.fmt.pix.width = frameWidth / 2;
     //m_videoFormat.fmt.pix.height = frameHeight;
@@ -156,8 +158,9 @@ aditof::Status BufferProcessor::setVideoProperties(int frameWidth,
     }
     m_processedBuffer = new uint16_t[m_outputFrameWidth * m_outputFrameHeight];
 
-    size_t rawFrameSize = static_cast<size_t>(m_outputFrameWidth) * m_outputFrameHeight;
+    size_t rawFrameSize = static_cast<size_t>(m_outputFrameWidth) * m_outputFrameHeight * 1.625;
 
+    rawFrameBufferSize = rawFrameSize;
     preallocatedFrameBuffers.reserve(10);
     {
         std::lock_guard<std::mutex> lock(preallocMutex);
@@ -170,9 +173,12 @@ aditof::Status BufferProcessor::setVideoProperties(int frameWidth,
         }
     }
 
-    ssize_t tofiBufferSize =  m_outputFrameWidth * m_outputFrameHeight * sizeof(uint16_t) +
-                             m_outputFrameWidth * m_outputFrameHeight * sizeof(uint8_t) +
-                             m_outputFrameWidth * m_outputFrameHeight * sizeof(float);
+    ssize_t tofiBufferSize =  m_outputFrameWidth * m_outputFrameHeight+
+                             m_outputFrameWidth * m_outputFrameHeight +
+                             m_outputFrameWidth * m_outputFrameHeight ;
+
+	//tofiBufferSize *= 4;
+
 
     for (int i = 0; i < TOFI_BUFFER_COUNT; ++i) {
         uint16_t* buffer = static_cast<uint16_t*>(aligned_alloc(64, tofiBufferSize));
@@ -182,6 +188,7 @@ aditof::Status BufferProcessor::setVideoProperties(int frameWidth,
         }
     }
 
+    LOG(INFO) << __func__ << ": RawBufferSize: " << rawFrameBufferSize << "  tofiBufferSize: " << tofiBufferSize;
     return status;
 }
 
@@ -280,6 +287,9 @@ void BufferProcessor::captureFrameThread() {
         auto captureEnd = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double, std::milli> captureTime = captureEnd - captureStart;
         totalCaptureTime += static_cast<long long>(captureTime.count());
+
+	if(totalV4L2Captured == 0)
+		LOG(INFO) << __func__ << ": V4l2 frame size: " << buf_data_len;
         totalV4L2Captured++;
 
         Frame frame;
@@ -420,6 +430,7 @@ aditof::Status BufferProcessor::processBuffer(uint16_t *buffer = nullptr) {
         processedBufferQueue.pop();
     }
 
+    frame.size= 7340160;
     if (buffer && frame.tofiBuffer && frame.size > 0) {
         memcpy(buffer, frame.tofiBuffer.get(), frame.size);
     } else {

--- a/sdk/src/connections/target/buffer_processor.cpp
+++ b/sdk/src/connections/target/buffer_processor.cpp
@@ -156,6 +156,29 @@ aditof::Status BufferProcessor::setVideoProperties(int frameWidth,
     }
     m_processedBuffer = new uint16_t[m_outputFrameWidth * m_outputFrameHeight];
 
+    size_t rawFrameSize = static_cast<size_t>(m_outputFrameWidth) * m_outputFrameHeight;
+
+    preallocatedFrameBuffers.reserve(10);
+    {
+        std::lock_guard<std::mutex> lock(preallocMutex);
+        for (int i = 0; i < 10; ++i) {
+            preallocatedFrameBuffers.emplace_back(rawFrameSize);  // vector with rawFrameSize capacity
+            freeFrameBuffers.push(&preallocatedFrameBuffers.back());
+        }
+    }
+
+    ssize_t tofiBufferSize =  m_outputFrameWidth * m_outputFrameHeight * sizeof(uint16_t) +
+                             m_outputFrameWidth * m_outputFrameHeight * sizeof(uint8_t) +
+                             m_outputFrameWidth * m_outputFrameHeight * sizeof(float);
+
+    for (int i = 0; i < TOFI_BUFFER_COUNT; ++i) {
+        uint16_t* buffer = static_cast<uint16_t*>(aligned_alloc(64, tofiBufferSize));
+        if (buffer) {
+            std::lock_guard<std::mutex> lock(tofiBufferMutex);
+            tofiBufferfifo.push(buffer);
+        }
+    }
+
     return status;
 }
 
@@ -210,87 +233,197 @@ aditof::Status BufferProcessor::setProcessorProperties(
     return aditof::Status::OK;
 }
 
+void BufferProcessor::captureFrameThread() {
+    LOG(INFO) << __func__ << ": Capture thread started";
+
+    long long totalCaptureTime = 0;
+    int totalV4L2Captured = 0;
+
+    size_t bufferIndex = 0;
+    size_t preallocSize = preallocatedFrameBuffers.size();
+
+    while (!stopThreadsFlag) {
+        aditof::Status status;
+        struct v4l2_buffer buf;
+        struct VideoDev *dev = m_inputVideoDev;
+        uint8_t *pdata = nullptr;
+        unsigned int buf_data_len = 0;
+
+        auto captureStart = std::chrono::high_resolution_clock::now();
+
+        status = waitForBufferPrivate(dev);
+        if (status != aditof::Status::OK){
+            LOG(ERROR) << __func__ << ": waitForBufferPrivate() Failed, retrying...";
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            continue;
+        }
+
+        status = dequeueInternalBufferPrivate(buf, dev);
+        if (status != aditof::Status::OK){
+            LOG(ERROR) << __func__ << ": dequeueInternalBufferPrivate() Failed, retrying...";
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            continue;
+        }
+
+        status = getInternalBufferPrivate(&pdata, buf_data_len, buf, dev);
+        if (status != aditof::Status::OK || !pdata || buf_data_len == 0) {
+            LOG(ERROR) << __func__ << ": dequeueInternalBufferPrivate() Failed. Buffer index: " << buf.index;
+            // Always requeue the buffer to avoid memory leak
+            enqueueInternalBufferPrivate(buf, dev);
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            continue;
+        }
+
+        auto captureEnd = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double, std::milli> captureTime = captureEnd - captureStart;
+        totalCaptureTime += static_cast<long long>(captureTime.count());
+        totalV4L2Captured++;
+
+        Frame frame;
+        {
+            std::lock_guard<std::mutex> lock(poolMutex);
+            if (bufferPool.size() >= preallocSize)
+                bufferPool.pop();
+
+            std::vector<uint8_t>& targetBuffer = preallocatedFrameBuffers[bufferIndex];
+            targetBuffer.assign(pdata, pdata + buf_data_len);
+
+            frame.data = targetBuffer;
+            frame.size = buf_data_len;
+
+            bufferPool.push(std::move(frame));
+            bufferNotEmpty.notify_one();
+
+            bufferIndex = (bufferIndex + 1) % preallocSize;
+        }
+
+        status = enqueueInternalBufferPrivate(buf, dev);
+        if (status != aditof::Status::OK) {
+            LOG(ERROR) << __func__ << ": enqueueInternalBufferPrivate() Failed";
+        }
+        // (Optional) A short sleep to avoid hammering the device, if needed.
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    if (totalV4L2Captured > 0) {
+        double averageCaptureTime = static_cast<double>(totalCaptureTime) / totalV4L2Captured;
+        LOG(INFO) << __func__ << ": Average capture time: " << averageCaptureTime << " ms";
+    }
+}
+
+void BufferProcessor::processThread() {
+    LOG(INFO) << __func__ << ": Processing thread started";
+
+    long long totalProcessTime = 0;
+    int totalProcessedFrame = 0;
+
+    while (!stopThreadsFlag) {
+        Frame frame;
+        {
+            std::unique_lock<std::mutex> lock(poolMutex);
+            if (!bufferNotEmpty.wait_for(lock, std::chrono::seconds(2), [this] { return !bufferPool.empty() || stopThreadsFlag; })) {
+                LOG(WARNING) << __func__ << ": Timeout! No new frames.";
+                continue;
+            }
+
+            if (stopThreadsFlag) break;
+
+            frame = std::move(bufferPool.front());
+            bufferPool.pop();
+        }
+
+        // Fetch a buffer from tofiBufferPool
+        uint16_t* tofiBuffer = nullptr;
+        {
+            std::unique_lock<std::mutex> tofiLock(tofiBufferMutex);
+            if (!tofiBufferNotEmpty.wait_for(tofiLock, std::chrono::seconds(2), [this] { return !tofiBufferfifo.empty(); })) {
+                LOG(WARNING) << __func__ << ": No available ToFi buffers, skipping frame!";
+                continue;
+            }
+
+            tofiBuffer = tofiBufferfifo.front();
+            tofiBufferfifo.pop();
+        }
+
+        uint16_t *tempDepthFrame = m_tofiComputeContext->p_depth_frame;
+        uint16_t *tempAbFrame = m_tofiComputeContext->p_ab_frame;
+        float *tempConfFrame = m_tofiComputeContext->p_conf_frame;
+
+        if (tofiBuffer) {
+            m_tofiComputeContext->p_depth_frame = tofiBuffer;
+            m_tofiComputeContext->p_ab_frame = tofiBuffer + m_outputFrameWidth * m_outputFrameHeight / 4;
+            m_tofiComputeContext->p_conf_frame = (float *)(tofiBuffer + m_outputFrameWidth * m_outputFrameHeight / 2);
+
+            auto processStart = std::chrono::high_resolution_clock::now();
+
+            uint32_t ret = TofiCompute(reinterpret_cast<uint16_t *>(frame.data.data()), m_tofiComputeContext, NULL);
+            if (ret != ADI_TOFI_SUCCESS) {
+                LOG(ERROR) << __func__ << ": TofiCompute failed Skipping frame!";
+                 {
+                    std::lock_guard<std::mutex> lock(tofiBufferMutex);
+                    tofiBufferfifo.push(tofiBuffer);
+                    tofiBufferNotEmpty.notify_one();
+                }
+                continue;
+            }
+
+            auto processEnd = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double, std::milli> processTime = processEnd - processStart;
+            totalProcessTime += static_cast<long long>(processTime.count());
+            totalProcessedFrame++;
+
+            m_tofiComputeContext->p_depth_frame = tempDepthFrame;
+            m_tofiComputeContext->p_ab_frame = tempAbFrame;
+            m_tofiComputeContext->p_conf_frame = tempConfFrame;
+        }
+
+        frame.tofiBuffer = std::shared_ptr<uint16_t>(
+            tofiBuffer,
+            [this](uint16_t* ptr) {
+                {
+                    std::lock_guard<std::mutex> lock(tofiBufferMutex);
+                    tofiBufferfifo.push(ptr);
+                }
+                tofiBufferNotEmpty.notify_one();
+            }
+        );
+        {
+            std::lock_guard<std::mutex> processedLock(processedMutex);
+            processedBufferQueue.push(std::move(frame));
+            processedNotEmpty.notify_one();
+        }
+    }
+    if (totalProcessedFrame > 0) {
+        double averageProcessTime = static_cast<double>(totalProcessTime) / totalProcessedFrame;
+        LOG(INFO) << __func__ << ": Average tofi_comupte process time: " << averageProcessTime << " ms";
+    }
+}
+
 aditof::Status BufferProcessor::processBuffer(uint16_t *buffer = nullptr) {
-    using namespace aditof;
-    struct v4l2_buffer buf[4];
-    struct VideoDev *dev;
-    Status status;
-    unsigned int buf_data_len;
-    uint8_t *pdata;
-    dev = m_inputVideoDev;
-    uint8_t *pdata_user_space = nullptr;
-
-    status = waitForBufferPrivate(dev);
-    if (status != Status::OK) {
-        return status;
-    }
-
-    status = dequeueInternalBufferPrivate(buf[0], dev);
-    if (status != Status::OK) {
-        return status;
-    }
-
-    status = getInternalBufferPrivate(&pdata, buf_data_len, buf[0], dev);
-    if (status != Status::OK) {
-        return status;
-    }
-
-    pdata_user_space = (uint8_t *)malloc(sizeof(uint8_t) * buf_data_len);
-    memcpy(pdata_user_space, pdata, buf_data_len);
-
-    uint16_t *tempDepthFrame = m_tofiComputeContext->p_depth_frame;
-    uint16_t *tempAbFrame = m_tofiComputeContext->p_ab_frame;
-    float *tempConfFrame = m_tofiComputeContext->p_conf_frame;
-
-    if (buffer != nullptr) {
-        m_tofiComputeContext->p_depth_frame = buffer;
-        m_tofiComputeContext->p_ab_frame =
-            buffer + m_outputFrameWidth * m_outputFrameHeight / 4;
-        m_tofiComputeContext->p_conf_frame =
-            (float *)(buffer + m_outputFrameWidth * m_outputFrameHeight / 2);
-
-        uint32_t ret = TofiCompute((uint16_t *)pdata_user_space,
-                                   m_tofiComputeContext, NULL);
-
-        if (ret != ADI_TOFI_SUCCESS) {
-            LOG(ERROR) << "TofiCompute failed";
-            return Status::GENERIC_ERROR;
+    Frame frame;
+    {
+        std::unique_lock<std::mutex> processedLock(processedMutex);
+        if (!processedNotEmpty.wait_for(processedLock, std::chrono::seconds(2), [this] { return !processedBufferQueue.empty() || stopThreadsFlag; })) {
+            LOG(WARNING) << __func__ << ": Timeout! No processed frames.";
+            return aditof::Status::GENERIC_ERROR;
         }
 
+        if (processedBufferQueue.empty()) {
+            LOG(ERROR) << __func__ << ": No processed frame available!";
+            return aditof::Status::GENERIC_ERROR;
+        }
+
+        frame = std::move(processedBufferQueue.front());
+        processedBufferQueue.pop();
+    }
+
+    if (buffer && frame.tofiBuffer && frame.size > 0) {
+        memcpy(buffer, frame.tofiBuffer.get(), frame.size);
     } else {
-
-        m_tofiComputeContext->p_depth_frame = m_processedBuffer;
-        m_tofiComputeContext->p_ab_frame =
-            m_processedBuffer + m_outputFrameWidth * m_outputFrameHeight / 4;
-        m_tofiComputeContext->p_conf_frame =
-            (float *)(m_processedBuffer +
-                      m_outputFrameWidth * m_outputFrameHeight / 2);
-
-        uint32_t ret = TofiCompute((uint16_t *)pdata_user_space,
-                                   m_tofiComputeContext, NULL);
-
-        if (ret != ADI_TOFI_SUCCESS) {
-            LOG(ERROR) << "TofiCompute failed";
-            return Status::GENERIC_ERROR;
-        }
-
-        ::write(m_outputVideoDev->fd, m_processedBuffer,
-                m_outputFrameWidth * m_outputFrameHeight);
+        LOG(ERROR) << "Invalid buffer or size!";
+        return aditof::Status::GENERIC_ERROR;
     }
 
-    m_tofiComputeContext->p_depth_frame = tempDepthFrame;
-    m_tofiComputeContext->p_ab_frame = tempAbFrame;
-    m_tofiComputeContext->p_conf_frame = tempConfFrame;
-
-    if (pdata_user_space)
-        free(pdata_user_space);
-
-    status = enqueueInternalBufferPrivate(buf[0], dev);
-    if (status != Status::OK) {
-        return status;
-    }
-
-    return status;
+    return aditof::Status::OK;
 }
 
 aditof::Status BufferProcessor::waitForBufferPrivate(struct VideoDev *dev) {
@@ -414,4 +547,42 @@ TofiConfig *BufferProcessor::getTofiCongfig() { return m_tofiConfig; }
 aditof::Status BufferProcessor::getDepthComputeVersion(uint8_t &enabled) {
     enabled = depthComputeOpenSourceEnabled;
     return aditof::Status::OK;
+}
+
+void BufferProcessor::startThreads() {
+    stopThreadsFlag = false;
+    streamRunning = true;
+
+    LOG(INFO) << __func__ << ": Starting Threads..";
+    captureThread = std::thread(&BufferProcessor::captureFrameThread, this);
+    processingThread = std::thread(&BufferProcessor::processThread, this);
+}
+
+void BufferProcessor::stopThreads() {
+
+    {
+        std::lock_guard<std::mutex> lock(poolMutex);
+        stopThreadsFlag = true;
+        bufferNotEmpty.notify_all();
+    }
+    {
+        std::lock_guard<std::mutex> lock(tofiBufferMutex);
+        tofiBufferNotEmpty.notify_all();  // Wake up processThread from tofiBuffer wait
+    }
+
+    if (captureThread.joinable())
+        captureThread.join();
+    if (processingThread.joinable())
+        processingThread.join();
+
+    {
+        std::lock_guard<std::mutex> lock(tofiBufferMutex);
+        while (!tofiBufferfifo.empty()) {
+            free(tofiBufferfifo.front());
+            tofiBufferfifo.pop();
+        }
+    }
+
+    LOG(INFO) << __func__ << ": Threads Stopped..";
+    streamRunning = false;
 }

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -130,13 +130,11 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     struct VideoDev *m_outputVideoDev;
 
     struct Frame {
-        std::vector<uint8_t> data;
-        size_t size;
+        uint8_t* data = nullptr;
+        size_t size = 0;
         std::shared_ptr<uint16_t> tofiBuffer;
 
         Frame() = default;
-        Frame(std::vector<uint8_t>&& d, size_t s) : data(std::move(d)), size(s), tofiBuffer(nullptr) {}
-
     };
 
     std::queue<Frame> bufferPool;
@@ -147,10 +145,12 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     bool stopThreadsFlag = false;
     bool streamRunning = false;
 
-    std::vector<std::vector<uint8_t>> preallocatedFrameBuffers;
-    std::queue<std::vector<uint8_t>*> freeFrameBuffers;
+    std::vector<uint8_t*> preallocatedFrameBuffers;
+    std::queue<uint8_t*> freeFrameBuffers;
     std::mutex preallocMutex;
     std::condition_variable preallocNotEmpty;
+
+    size_t rawFrameBufferSize = 0;
 
     std::thread captureThread;
     std::thread processingThread;

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -149,6 +149,7 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     std::queue<uint8_t*> freeFrameBuffers;
     std::mutex preallocMutex;
     std::condition_variable preallocNotEmpty;
+    std::condition_variable bufferNotFull, processedNotFull;
 
     size_t rawFrameBufferSize = 0;
 

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -179,19 +179,19 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     struct VideoDev *m_outputVideoDev;
 
     struct Tofi_v4l2_buffer {
-        uint8_t *data = nullptr;
+        std::shared_ptr<uint8_t> data;
         size_t size = 0;
-        uint16_t *tofiBuffer = nullptr;
+        std::shared_ptr<uint16_t> tofiBuffer;
     };
 
     // Thread-safe pool of empty raw frame buffers for use by capture thread
-    ThreadSafeQueue<uint8_t *> m_v4l2_input_buffer_Q;
+    ThreadSafeQueue<std::shared_ptr<uint8_t>> m_v4l2_input_buffer_Q;
 
     // Thread-safe queue to transfer captured raw frames to the process thread
     ThreadSafeQueue<Tofi_v4l2_buffer> m_capture_to_process_Q;
 
     // Thread-safe pool of ToFi compute output buffers (depth + AB + confidence)
-    ThreadSafeQueue<uint16_t *> m_tofi_io_Buffer_Q;
+    ThreadSafeQueue<std::shared_ptr<uint16_t>> m_tofi_io_Buffer_Q;
 
     // Thread-safe queue for frames that have been fully processed (compute done)
     ThreadSafeQueue<Tofi_v4l2_buffer> m_process_done_Q;

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -33,6 +33,7 @@
 #include <queue>
 #include <vector>
 #include <mutex>
+#include <atomic>
 #include <condition_variable>
 
 #include "v4l_buffer_access_interface.h"
@@ -60,6 +61,49 @@ struct VideoDev {
     VideoDev()
         : fd(-1), sfd(-1), videoBuffers(nullptr), nVideoBuffers(0),
           started(false) {}
+};
+
+template <typename T>
+class ThreadSafeQueue {
+private:
+    std::queue<T> queue_;
+    mutable std::mutex mutex_;
+    std::condition_variable not_empty_;
+    std::condition_variable not_full_;
+    size_t max_size_;
+
+public:
+    explicit ThreadSafeQueue(size_t max_size) : max_size_(max_size) {}
+
+    bool push(T item, std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        if (!not_full_.wait_until(lock, deadline, [this] { return queue_.size() < max_size_; })) {
+            return false;
+        }
+        queue_.push(std::move(item));
+        lock.unlock();
+        not_empty_.notify_all();
+        return true;
+    }
+
+    bool pop(T& item, std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        if (!not_empty_.wait_until(lock, deadline, [this] { return !queue_.empty(); })) {
+            return false;
+        }
+        item = std::move(queue_.front());
+        queue_.pop();
+        lock.unlock();
+        not_full_.notify_all();
+        return true;
+    }
+
+    size_t size() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return queue_.size();
+    }
 };
 
 class BufferProcessor : public aditof::V4lBufferAccessInterface {
@@ -129,37 +173,31 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     struct VideoDev *m_inputVideoDev;
     struct VideoDev *m_outputVideoDev;
 
+
     struct Frame {
         uint8_t* data = nullptr;
         size_t size = 0;
-        std::shared_ptr<uint16_t> tofiBuffer;
-
-        Frame() = default;
+        uint16_t* tofiBuffer = nullptr;
     };
 
-    std::queue<Frame> bufferPool;
-    std::queue<Frame> processedBufferQueue;
-
-    std::mutex poolMutex, processedMutex;
-    std::condition_variable bufferNotEmpty, processedNotEmpty;
-    bool stopThreadsFlag = false;
-    bool streamRunning = false;
+    ThreadSafeQueue<Frame> bufferPool;
+    ThreadSafeQueue<Frame> processedBufferQueue;
+    ThreadSafeQueue<uint16_t*> tofiBufferQueue;
+    ThreadSafeQueue<uint8_t*> freeFrameBufferQueue;
 
     std::vector<uint8_t*> preallocatedFrameBuffers;
-    std::queue<uint8_t*> freeFrameBuffers;
+    std::vector<uint16_t*> tofiBuffers;
     std::mutex preallocMutex;
-    std::condition_variable preallocNotEmpty;
-    std::condition_variable bufferNotFull, processedNotFull;
 
-    size_t rawFrameBufferSize = 0;
-    uint32_t tofiBufferSize = 0;
-
+    size_t rawFrameBufferSize;
+    uint32_t tofiBufferSize;
     std::thread captureThread;
     std::thread processingThread;
+    std::atomic<bool> stopThreadsFlag;
+    std::atomic<size_t> processedFrames;
+    bool streamRunning = false;
 
-    std::queue<uint16_t*> tofiBufferfifo;
-    std::mutex tofiBufferMutex;
-    std::condition_variable tofiBufferNotEmpty;
+    static constexpr int TOFI_BUFFER_COUNT = 10;
+    static constexpr size_t MAX_QUEUE_SIZE = 50;
 
-    static constexpr int TOFI_BUFFER_COUNT = 10;  // Or more depending on performance needs
 };

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -205,7 +205,8 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     std::atomic<bool> stopThreadsFlag;
     bool streamRunning = false;
 
-    static constexpr int TOFI_BUFFER_COUNT = 10;
-    static constexpr size_t MAX_QUEUE_SIZE = 10;
+    static constexpr size_t MAX_QUEUE_SIZE = 3;
     static constexpr int TIME_OUT_DELAY = 5;
+
+    int m_maxTries = 3;
 };

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -114,7 +114,7 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
   public:
     aditof::Status open();
     aditof::Status setInputDevice(VideoDev *inputVideoDev);
-    aditof::Status setVideoProperties(int frameWidth, int frameHeight);
+    aditof::Status setVideoProperties(int frameWidth, int frameHeight, int WidthInBytes, int HeightInBytes);
     aditof::Status setProcessorProperties(uint8_t *iniFile,
                                           uint16_t iniFileLength,
                                           uint8_t *calData,

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -152,6 +152,7 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     std::condition_variable bufferNotFull, processedNotFull;
 
     size_t rawFrameBufferSize = 0;
+    uint32_t tofiBufferSize = 0;
 
     std::thread captureThread;
     std::thread processingThread;

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -174,14 +174,14 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     struct VideoDev *m_outputVideoDev;
 
 
-    struct Frame {
+    struct Tofi_v4l2_buffer {
         uint8_t* data = nullptr;
         size_t size = 0;
         uint16_t* tofiBuffer = nullptr;
     };
 
-    ThreadSafeQueue<Frame> bufferPool;
-    ThreadSafeQueue<Frame> processedBufferQueue;
+    ThreadSafeQueue<Tofi_v4l2_buffer> bufferPool;
+    ThreadSafeQueue<Tofi_v4l2_buffer> processedBufferQueue;
     ThreadSafeQueue<uint16_t*> tofiBufferQueue;
     ThreadSafeQueue<uint8_t*> freeFrameBufferQueue;
 

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -29,6 +29,11 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <thread>
+#include <queue>
+#include <vector>
+#include <mutex>
+#include <condition_variable>
 
 #include "v4l_buffer_access_interface.h"
 
@@ -75,6 +80,9 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     TofiConfig *getTofiCongfig();
     aditof::Status getDepthComputeVersion(uint8_t &enabled);
 
+    void startThreads();
+    void stopThreads();
+
   public:
     virtual aditof::Status waitForBuffer() override;
     virtual aditof::Status
@@ -98,6 +106,9 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
     aditof::Status enqueueInternalBufferPrivate(struct v4l2_buffer &buf,
                                                 struct VideoDev *dev = nullptr);
 
+    void captureFrameThread();
+    void processThread();
+
   private:
     bool m_vidPropSet;
     bool m_processorPropSet;
@@ -117,4 +128,36 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
 
     struct VideoDev *m_inputVideoDev;
     struct VideoDev *m_outputVideoDev;
+
+    struct Frame {
+        std::vector<uint8_t> data;
+        size_t size;
+        std::shared_ptr<uint16_t> tofiBuffer;
+
+        Frame() = default;
+        Frame(std::vector<uint8_t>&& d, size_t s) : data(std::move(d)), size(s), tofiBuffer(nullptr) {}
+
+    };
+
+    std::queue<Frame> bufferPool;
+    std::queue<Frame> processedBufferQueue;
+
+    std::mutex poolMutex, processedMutex;
+    std::condition_variable bufferNotEmpty, processedNotEmpty;
+    bool stopThreadsFlag = false;
+    bool streamRunning = false;
+
+    std::vector<std::vector<uint8_t>> preallocatedFrameBuffers;
+    std::queue<std::vector<uint8_t>*> freeFrameBuffers;
+    std::mutex preallocMutex;
+    std::condition_variable preallocNotEmpty;
+
+    std::thread captureThread;
+    std::thread processingThread;
+
+    std::queue<uint16_t*> tofiBufferfifo;
+    std::mutex tofiBufferMutex;
+    std::condition_variable tofiBufferNotEmpty;
+
+    static constexpr int TOFI_BUFFER_COUNT = 10;  // Or more depending on performance needs
 };


### PR DESCRIPTION
1) Done naming conventions.
2) Added 3 retry functionality.
3) Reduce the queue size to 3, will allocate less memory.
4) Used shared pointer instead of raw pointer.
5) Reduce delay to 5 Ms.
6) Used macro for delay.
7) Check for nullptr before "memcpy" in capture thread.
8) Added stop thread breaking functionality while popping buffer in thread.
9) Remove BUSY return in "processBuffer()" call.
10) Added comments to important part of code.
11) Simplified the "m_tofiComputeContext" buffer offset calculation.
12) Done clang-formatting on code.
