### PR TITLE
Support adcam changes

### DIFF
--- a/sdk/include/aditof/camera.h
+++ b/sdk/include/aditof/camera.h
@@ -354,6 +354,13 @@ class SDK_API Camera {
     virtual Status adsd3500SetMIPIOutputSpeed(uint16_t speed) = 0;
 
     /**
+     * @brief Set Enable Deskew at stream on
+     * @param[in] value - See "Set Enable Deskew at stream on" at https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175x-adsd3500
+     * @return Status
+     */
+    virtual Status adsd3500SetEnableDeskewAtStreamOn(uint16_t value) = 0;
+
+    /**
      * @brief Get ADSD3500 MIPI output speed
      * @param[out] speed - See "Get MIPI Output Speed" at https://wiki.analog.com/resources/eval/user-guides/eval-adtf3175x-adsd3500
      * @return Status

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -98,6 +98,7 @@ class CameraItof : public aditof::Camera {
                                               std::string &fwHash) override;
     aditof::Status adsd3500SetMIPIOutputSpeed(uint16_t speed) override;
     aditof::Status adsd3500GetMIPIOutputSpeed(uint16_t &speed) override;
+    aditof::Status adsd3500SetEnableDeskewAtStreamOn(uint16_t value) override;
     aditof::Status adsd3500GetImagerErrorCode(uint16_t &errcode) override;
     aditof::Status adsd3500SetVCSELDelay(uint16_t delay) override;
     aditof::Status adsd3500GetVCSELDelay(uint16_t &delay) override;
@@ -244,6 +245,7 @@ class CameraItof : public aditof::Camera {
     int16_t m_cameraFps;
     int16_t m_fsyncMode;
     int16_t m_mipiOutputSpeed;
+    uint16_t m_isdeskewEnabled;
     int16_t m_enableTempCompenstation;
     int16_t m_enableMetaDatainAB;
     int16_t m_enableEdgeConfidence;

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -42,17 +42,26 @@
 
 #define CLEAR(x) memset(&(x), 0, sizeof(x))
 
-#define V4L2_CID_AD_DEV_CHIP_CONFIG (0x9819e1)
 #define CTRL_PACKET_SIZE 65537
+#define CTRL_SET_FRAME_RATE (0x9a200b)
+#define V4L2_CID_AD_DEV_CHIP_CONFIG (0x9819d1)
+#define CTRL_SET_MODE (0x9819d0)
+#define CTRL_AB_AVG (0x9819d5)
+#define CTRL_DEPTH_EN (0x9819d6)
+#define CTRL_PHASE_DEPTH_BITS (0x9819d2)
+#define CTRL_AB_BITS (0x9819d3)
+#define CTRL_CONFIDENCE_BITS (0x9819d4)
+
+#ifdef NXP
+#define V4L2_CID_AD_DEV_CHIP_CONFIG (0x9819e1)
 #define CTRL_SET_MODE (0x9819e0)
 #define CTRL_AB_AVG (0x9819e5)
 #define CTRL_DEPTH_EN (0x9819e6)
 #define CTRL_PHASE_DEPTH_BITS (0x9819e2)
 #define CTRL_AB_BITS (0x9819e3)
 #define CTRL_CONFIDENCE_BITS (0x9819e4)
-#ifdef NVIDIA
-#define CTRL_SET_FRAME_RATE (0x9a200b)
 #endif
+
 #define ADSD3500_CTRL_PACKET_SIZE 4099
 // Can be moved to target_definitions in "camera"/"platform"
 #define TEMP_SENSOR_DEV_PATH "/dev/i2c-1"
@@ -154,11 +163,11 @@ Adsd3500Sensor::Adsd3500Sensor(const std::string &driverPath,
     m_controls.emplace("availableCCBM", "0");
 
     // Define the commands that correspond to the sensor controls
-    m_implData->controlsCommands["abAveraging"] = 0x9819e5;
-    m_implData->controlsCommands["depthEnable"] = 0x9819e6;
-    m_implData->controlsCommands["phaseDepthBits"] = 0x9819e2;
-    m_implData->controlsCommands["abBits"] = 0x9819e3;
-    m_implData->controlsCommands["confidenceBits"] = 0x9819e4;
+    m_implData->controlsCommands["abAveraging"] = CTRL_AB_AVG;
+    m_implData->controlsCommands["depthEnable"] = CTRL_DEPTH_EN;
+    m_implData->controlsCommands["phaseDepthBits"] = CTRL_PHASE_DEPTH_BITS;
+    m_implData->controlsCommands["abBits"] = CTRL_AB_BITS;
+    m_implData->controlsCommands["confidenceBits"] = CTRL_CONFIDENCE_BITS;
 
     m_bufferProcessor = new BufferProcessor();
 }
@@ -1436,10 +1445,10 @@ aditof::Status Adsd3500Sensor::adsd3500_reset() {
     }
 #elif defined(NVIDIA)
     struct stat st;
-    if (stat("/sys/class/gpio/PP.04/value", &st) == 0) {
-        system("echo 0 > /sys/class/gpio/PP.04/value");
+    if (stat("/sys/class/gpio/PH.06/value", &st) == 0) {
+        system("echo 0 > /sys/class/gpio/PH.06/value");
         usleep(100000);
-        system("echo 1 > /sys/class/gpio/PP.04/value");
+        system("echo 1 > /sys/class/gpio/PH.06/value");
         usleep(5000000);
     } else {
         Gpio gpio11("/dev/gpiochip3", 11);


### PR DESCRIPTION
- Set MIPI output speed to 2.5Gbps by default if not set by config in case of NVIDIA.
- introduced API to enable deskew at stream-on 
- set V4l2 control is for NVIDIA by default.
- update adsd3500 GPIO for NVIDIA