### PR TITLE
fix(camera): swap dimensions for rotation + improve imager detection

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -678,17 +678,45 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
             m_depthSensor->setControl("lensScatterCompensationEnabled", "0");
         }
 
-        // Apply VGA rotation setting from JSON config
-        auto rotationIt = m_iniKeyValPairs.find("enableRotation");
-        if (rotationIt != m_iniKeyValPairs.end()) {
-            m_depthSensor->setControl("enableRotation", rotationIt->second);
-        }
-
         status = m_depthSensor->setMode(mode);
         if (status != Status::OK) {
             LOG(WARNING) << "Failed to set frame type";
             return status;
         }
+
+        // Apply VGA rotation setting
+        // ADTF3066: rotation enabled by default; only override if user explicitly loaded a JSON
+        // Other imagers: rotation disabled by default; respect JSON if present
+        std::string rotationValue;
+        auto rotationIt = m_iniKeyValPairs.find("enableRotation");
+
+        if (m_imagerType == aditof::ImagerType::ADTF3066) {
+            if (m_userJsonLoaded && rotationIt != m_iniKeyValPairs.end()) {
+                // User explicitly loaded JSON - respect their setting
+                rotationValue = rotationIt->second;
+                LOG(INFO) << "ADTF3066 rotation overridden by user JSON: "
+                          << rotationValue;
+            } else {
+                // Default: enabled for ADTF3066
+                rotationValue = "1";
+                m_iniKeyValPairs["enableRotation"] = rotationValue;
+                m_depth_params_map[mode] = m_iniKeyValPairs;
+                LOG(INFO) << "ADTF3066 rotation enabled by default";
+            }
+        } else {
+            if (rotationIt != m_iniKeyValPairs.end()) {
+                rotationValue = rotationIt->second;
+                LOG(INFO) << "Rotation from JSON config: " << rotationValue;
+            } else {
+                rotationValue = "0";
+                m_iniKeyValPairs["enableRotation"] = rotationValue;
+                m_depth_params_map[mode] = m_iniKeyValPairs;
+                LOG(INFO) << "Rotation using default: disabled";
+            }
+        }
+
+        // Always apply the rotation control after setMode
+        m_depthSensor->setControl("enableRotation", rotationValue);
 
         status = m_depthSensor->getModeDetails(mode, m_modeDetailsCache);
         if (status != Status::OK) {
@@ -774,9 +802,18 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
         }
 
         // Store the frame details in camera details
+        // When 90° rotation is enabled, the pixel data is transposed:
+        // the SDK buffer layout becomes H×W, so report swapped dimensions.
+        bool rotationEnabled = (rotationValue == "1");
+        uint32_t reportedWidth = m_modeDetailsCache.baseResolutionWidth;
+        uint32_t reportedHeight = m_modeDetailsCache.baseResolutionHeight;
+        if (rotationEnabled) {
+            std::swap(reportedWidth, reportedHeight);
+        }
+
         m_details.mode = mode;
-        m_details.frameType.width = m_modeDetailsCache.baseResolutionWidth;
-        m_details.frameType.height = m_modeDetailsCache.baseResolutionHeight;
+        m_details.frameType.width = reportedWidth;
+        m_details.frameType.height = reportedHeight;
         m_details.frameType.totalCaptures = 1;
         m_details.frameType.dataDetails.clear();
         // Use m_modeDetailsCache.frameContent (updated) not (*modeIt).frameContent (stale)
@@ -787,8 +824,8 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
 
             FrameDataDetails fDataDetails;
             fDataDetails.type = item;
-            fDataDetails.width = m_modeDetailsCache.baseResolutionWidth;
-            fDataDetails.height = m_modeDetailsCache.baseResolutionHeight;
+            fDataDetails.width = reportedWidth;
+            fDataDetails.height = reportedHeight;
             fDataDetails.subelementSize = sizeof(uint16_t);
             fDataDetails.subelementsPerElement = 1;
 
@@ -2556,6 +2593,7 @@ CameraItof::loadDepthParamsFromJsonFile(const std::string &pathFile,
 
     assert(!m_isOffline);
 
+    m_userJsonLoaded = true;
     m_depth_params_map.clear();
 
     // Parse json

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -258,6 +258,7 @@ class CameraItof : public aditof::Camera {
     XYZTable m_xyzTable;
     bool m_enableDepthCompute;
     std::string m_initConfigFilePath;
+    bool m_userJsonLoaded = false;
     aditof::ImagerType m_imagerType;
     bool m_dropFirstFrame;
     bool m_dropFrameOnce;

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -1071,10 +1071,13 @@ Adsd3500Sensor::setMode(const aditof::DepthSensorModeDetails &type) {
         uint8_t bitsInConf =
             skipToFiProcessing ? 0 : m_bitsInConf[type.modeNumber];
 
+        bool isADSD3100 =
+            (m_implData->imagerType == SensorImagerType::IMAGER_ADSD3100);
+
         status = m_bufferProcessor->setVideoProperties(
             type.baseResolutionWidth, type.baseResolutionHeight,
             type.frameWidthInBytes, type.frameHeightInBytes, type.modeNumber,
-            bitsInAB, bitsInConf, skipToFiProcessing);
+            bitsInAB, bitsInConf, skipToFiProcessing, isADSD3100);
         if (status != Status::OK) {
             LOG(ERROR) << "Failed to set bufferProcessor properties!";
             goto cleanup_on_error;
@@ -2413,6 +2416,7 @@ aditof::Status Adsd3500Sensor::queryAdsd3500() {
         m_implData->fw_ver = std::string((char *)(fwData), 4);
 
         uint16_t readValue = 0;
+        uint16_t revision_ver = 0;
         int majorVersion = m_implData->fw_ver.at(0);
         if (majorVersion ==
             0) { // 0 means beta version, so version start at position 1
@@ -2420,6 +2424,7 @@ aditof::Status Adsd3500Sensor::queryAdsd3500() {
         }
         if (majorVersion > 3) {
             status = adsd3500_read_cmd(0x0032, &readValue);
+            status = adsd3500_read_cmd(0x0115, &revision_ver);
         } else {
             status = Status::GENERIC_ERROR;
         }
@@ -2449,30 +2454,40 @@ aditof::Status Adsd3500Sensor::queryAdsd3500() {
             } // switch (ccb_version)
 
             uint8_t imager_version = (readValue & 0xFF00) >> 8;
+            revision_ver = revision_ver & 0x3;
+            imager_version = (revision_ver == 2)
+                                 ? (imager_version + revision_ver)
+                                 : imager_version;
             switch (imager_version) {
             case 1: {
                 m_implData->imagerType = SensorImagerType::IMAGER_ADSD3100;
                 m_modeSelector.setControl("imagerType", "adsd3100");
+                LOG(INFO) << "Detected imager: ADSD3100";
                 break;
             }
             case 2: {
-                m_implData->imagerType = SensorImagerType::IMAGER_ADSD3030;
-                m_modeSelector.setControl("imagerType", "adsd3030");
+                m_implData->imagerType = SensorImagerType::IMAGER_ADTF3066;
+                m_modeSelector.setControl("imagerType", "adtf3030");
+                LOG(INFO) << "Detected imager: ADSD3030";
                 break;
             }
             case 3: {
                 m_implData->imagerType = SensorImagerType::IMAGER_ADTF3080;
                 m_modeSelector.setControl("imagerType", "adtf3080");
+                LOG(INFO) << "Detected imager: ADTF3080";
                 break;
             }
             case 4: {
-                m_implData->imagerType = SensorImagerType::IMAGER_ADTF3066;
+                m_implData->imagerType = SensorImagerType::IMAGER_ADSD3030;
                 m_modeSelector.setControl("imagerType", "adtf3066");
+                LOG(INFO) << "Detected imager: ADTF3066";
                 break;
             }
             default: {
-                LOG(WARNING) << "Unknown imager type read from ADSD3500: "
-                             << imager_version;
+                LOG(WARNING) << "Unknown imager type read from ADSD3500: 0x"
+                             << std::hex << static_cast<int>(imager_version)
+                             << std::dec << " (register 0x0032 = 0x" << std::hex
+                             << readValue << std::dec << ")";
             }
             } // switch (imager_version)
         } else {

--- a/sdk/src/connections/target/buffer_processor.cpp
+++ b/sdk/src/connections/target/buffer_processor.cpp
@@ -229,7 +229,8 @@ aditof::Status BufferProcessor::setInputDevice(VideoDev *inputVideoDev) {
  */
 aditof::Status BufferProcessor::setVideoProperties(
     int frameWidth, int frameHeight, int WidthInBytes, int HeightInBytes,
-    int modeNumber, uint8_t bitsInAB, uint8_t bitsInConf, bool isRawBypass) {
+    int modeNumber, uint8_t bitsInAB, uint8_t bitsInConf, bool isRawBypass,
+    bool isADSD3100) {
 
     // Clear all queues to prevent memory leaks if setVideoProperties is called multiple times
     if (!stopThreadsFlag.load(std::memory_order_acquire)) {
@@ -257,6 +258,7 @@ aditof::Status BufferProcessor::setVideoProperties(
 
     m_currentModeNumber = modeNumber;
     m_isRawBypassMode = isRawBypass;
+    m_isADSD3100 = isADSD3100;
 
     m_outputFrameWidth = frameWidth;
     m_outputFrameHeight = frameHeight;
@@ -910,39 +912,58 @@ void BufferProcessor::processThread() {
                 // the AB section, not as a separate header before depth.
                 // So depth starts at offset 0.
 
-                // Always copy depth frame
-                memcpy(m_tofiComputeContext->p_depth_frame,
-                       process_frame.data.get(), numPixels * 2);
+                if (m_isADSD3100) {
+                    // Always copy depth frame
+                    memcpy(m_tofiComputeContext->p_depth_frame,
+                           process_frame.data.get(), numPixels * 2);
 
-                // Calculate actual sizes based on m_tofiBufferSize
-                // m_tofiBufferSize is in uint16_t units: depth + AB + conf
-                uint32_t remainingSize =
-                    m_tofiBufferSize -
-                    static_cast<uint32_t>(numPixels); // After depth
+                    // Calculate actual sizes based on m_tofiBufferSize
+                    // m_tofiBufferSize is in uint16_t units: depth + AB + conf
+                    uint32_t remainingSize =
+                        m_tofiBufferSize -
+                        static_cast<uint32_t>(numPixels); // After depth
 
-                // Copy AB frame if allocated (remainingSize > 0)
-                // AB section: first 128 bytes are metadata (extracted by requestFrame())
-                if (remainingSize > 0) {
-                    uint32_t abCopySize =
-                        std::min(remainingSize,
-                                 static_cast<uint32_t>(
-                                     numPixels)); // AB is at most numPixels
-                    memcpy(m_tofiComputeContext->p_ab_frame,
-                           process_frame.data.get() + numPixels * 2,
-                           abCopySize * 2);
-                    remainingSize -= abCopySize;
-                }
+                    // Copy AB frame if allocated (remainingSize > 0)
+                    // AB section: first 128 bytes are metadata (extracted by requestFrame())
+                    if (remainingSize > 0) {
+                        uint32_t abCopySize =
+                            std::min(remainingSize,
+                                     static_cast<uint32_t>(
+                                         numPixels)); // AB is at most numPixels
+                        memcpy(m_tofiComputeContext->p_ab_frame,
+                               process_frame.data.get() + numPixels * 2,
+                               abCopySize * 2);
+                        remainingSize -= abCopySize;
+                    }
 
-                // Copy confidence frame if allocated (remainingSize > 0 after AB)
-                // Confidence is numPixels*2 uint16_t (same as numPixels float)
-                if (remainingSize > 0) {
-                    uint32_t confCopySize =
-                        std::min(remainingSize,
-                                 static_cast<uint32_t>(numPixels * 2)) *
-                        2; // In bytes
-                    memcpy(m_tofiComputeContext->p_conf_frame,
-                           process_frame.data.get() + numPixels * 4,
-                           confCopySize);
+                    // Copy confidence frame if allocated (remainingSize > 0 after AB)
+                    // Confidence is numPixels*2 uint16_t (same as numPixels float)
+                    if (remainingSize > 0) {
+                        uint32_t confCopySize =
+                            std::min(remainingSize,
+                                     static_cast<uint32_t>(numPixels * 2)) *
+                            2; // In bytes
+                        memcpy(m_tofiComputeContext->p_conf_frame,
+                               process_frame.data.get() + numPixels * 4,
+                               confCopySize);
+                    }
+                } else {
+                    // Other imagers: Call TofiCompute for ISP pre-computed modes
+                    uint32_t ret = TofiCompute(
+                        reinterpret_cast<uint16_t *>(process_frame.data.get()),
+                        m_tofiComputeContext, NULL);
+
+                    if (ret != ADI_TOFI_SUCCESS) {
+                        LOG(ERROR) << "processThread: TofiCompute failed for "
+                                      "ISP mode, code: "
+                                   << ret;
+                        m_tofi_io_Buffer_Q.push(tofi_compute_io_buff);
+                        m_v4l2_input_buffer_Q.push(process_frame.data);
+                        m_tofiComputeContext->p_depth_frame = tempDepthFrame;
+                        m_tofiComputeContext->p_ab_frame = tempAbFrame;
+                        m_tofiComputeContext->p_conf_frame = tempConfFrame;
+                        continue;
+                    }
                 }
             } else if (m_currentModeNumber == 0 || m_currentModeNumber == 1) {
                 // Lens scatter mode for mode 0/1: Process raw Bayer data with TofiCompute

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -133,7 +133,8 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
                                       int WidthInBytes, int HeightInBytes,
                                       int modeNumber, uint8_t bitsInAB,
                                       uint8_t bitsInConf,
-                                      bool isRawBypass = false);
+                                      bool isRawBypass = false,
+                                      bool isADSD3100= false);
     aditof::Status setProcessorProperties(uint8_t *iniFile,
                                           uint16_t iniFileLength,
                                           uint8_t *calData,
@@ -249,6 +250,8 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
         m_lensScatterCompensationEnabled; // When true, raw bypass uses TofiCompute
     bool
         m_needsRotation; // When true, rotate frames 90 degrees clockwise (for ADTF3080)
+    bool
+        m_isADSD3100; // True for ADSD3100 imager
 
   public:
     // Stream record and playback support

--- a/sdk/src/connections/target/buffer_processor.h
+++ b/sdk/src/connections/target/buffer_processor.h
@@ -134,7 +134,7 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
                                       int modeNumber, uint8_t bitsInAB,
                                       uint8_t bitsInConf,
                                       bool isRawBypass = false,
-                                      bool isADSD3100= false);
+                                      bool isADSD3100 = false);
     aditof::Status setProcessorProperties(uint8_t *iniFile,
                                           uint16_t iniFileLength,
                                           uint8_t *calData,
@@ -250,8 +250,7 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface {
         m_lensScatterCompensationEnabled; // When true, raw bypass uses TofiCompute
     bool
         m_needsRotation; // When true, rotate frames 90 degrees clockwise (for ADTF3080)
-    bool
-        m_isADSD3100; // True for ADSD3100 imager
+    bool m_isADSD3100; // True for ADSD3100 imager
 
   public:
     // Stream record and playback support


### PR DESCRIPTION
Fix rotated frames displaying with wrong aspect ratio by swapping reported width/height when enableRotation=1. 
Improve ADTF3066/ADSD3100 detection via revision register.
Add ADSD3100 flag to buffer_processor. Apply clang-format.