### PR TITLE
fix(sdk): sync runtime config with buffer allocation arrays

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -655,6 +655,11 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
         }
 
         m_iniKeyValPairs = m_depth_params_map[mode];
+
+        // Set target mode on sensor BEFORE configureSensorModeDetails() so that
+        // runtime config bit depths (abBits, confidenceBits) update the correct
+        // mode's m_bitsInAB[]/m_bitsInConf[] arrays for buffer allocation
+        m_depthSensor->setControl("targetModeNumber", std::to_string(mode));
         configureSensorModeDetails();
 
         // Apply raw bypass mode setting before configuring V4L2 driver

--- a/sdk/src/connections/target/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500_sensor.cpp
@@ -236,6 +236,7 @@ Adsd3500Sensor::Adsd3500Sensor(const std::string &driverPath,
     m_controls.emplace("availableCCBM", "0");
     m_controls.emplace("lensScatterCompensationEnabled", "0");
     m_controls.emplace("enableRotation", "0");
+    m_controls.emplace("targetModeNumber", "-1");
 
     // Define the commands that correspond to the sensor controls
     m_implData->controlsCommands["abAveraging"] = CTRL_AB_AVG;
@@ -811,6 +812,8 @@ aditof::Status Adsd3500Sensor::setMode(const uint8_t &mode) {
     }
 
     m_implData->modeDetails = modeTable;
+    // Reset target mode now that setMode has used the updated bit arrays
+    m_targetModeNumber = -1;
     return aditof::Status::OK;
 }
 
@@ -1272,6 +1275,16 @@ aditof::Status Adsd3500Sensor::setControl(const std::string &control,
         return Status::OK;
     }
 
+    // Set the target mode for subsequent bit depth updates from runtime config.
+    // Must be called before configureSensorModeDetails() so that abBits/
+    // confidenceBits controls update the correct mode's arrays.
+    if (control == "targetModeNumber") {
+        m_targetModeNumber = (int8_t)std::stoi(value);
+        LOG(INFO) << "Target mode for runtime bit config set to "
+                  << (int)m_targetModeNumber;
+        return Status::OK;
+    }
+
     std::vector<std::string> convertor = {"0",  "4",  "8", "10",
                                           "12", "14", "16"};
 
@@ -1293,12 +1306,32 @@ aditof::Status Adsd3500Sensor::setControl(const std::string &control,
             return Status::INVALID_ARGUMENT;
         }
 
+        // Determine which mode's bit arrays to update:
+        // Use m_targetModeNumber if set (runtime config before setMode),
+        // otherwise fall back to current mode
+        uint8_t modeNum = (m_targetModeNumber >= 0)
+                              ? static_cast<uint8_t>(m_targetModeNumber)
+                              : m_implData->modeDetails.modeNumber;
+        uint8_t actualBits = (uint8_t)std::stoi(convertor[bitIndex]);
+
         if (control == "phaseDepthBits") {
             m_modeSelector.setControl("depthBits", convertor[bitIndex]);
         } else if (control == "abBits") {
             m_modeSelector.setControl("abBits", convertor[bitIndex]);
+            // Update runtime bit config so setMode/setVideoProperties uses correct value
+            if (modeNum < m_bitsInAB.size()) {
+                m_bitsInAB[modeNum] = actualBits;
+                LOG(INFO) << "Runtime config: m_bitsInAB[" << (int)modeNum
+                          << "] = " << (int)actualBits;
+            }
         } else if (control == "confidenceBits") {
             m_modeSelector.setControl("confBits", convertor[bitIndex]);
+            // Update runtime bit config so setMode/setVideoProperties uses correct value
+            if (modeNum < m_bitsInConf.size()) {
+                m_bitsInConf[modeNum] = actualBits;
+                LOG(INFO) << "Runtime config: m_bitsInConf[" << (int)modeNum
+                          << "] = " << (int)actualBits;
+            }
         }
     }
 

--- a/sdk/src/connections/target/adsd3500_sensor.h
+++ b/sdk/src/connections/target/adsd3500_sensor.h
@@ -225,6 +225,7 @@ class Adsd3500Sensor : public aditof::DepthSensorInterface,
     uint16_t m_chipId;
     bool m_lensScatterEnabled = false;
     bool m_rotationEnabled = false;
+    int8_t m_targetModeNumber = -1; 
 
   public:
     // Stream record and playback support


### PR DESCRIPTION
Fixes crash when updating bitsInAB/bitsInConf via runtime JSON by propagating changes to m_bitsInAB[]/m_bitsInConf[] arrays.