### PR TITLE
feat(sdk): add firmware version validation with configurable delay

### DIFF
--- a/sdk/src/cameras/itof-camera/config/firmware_version_config.json
+++ b/sdk/src/cameras/itof-camera/config/firmware_version_config.json
@@ -1,0 +1,4 @@
+{
+  "expectedFirmwareVersion": "7.2.0.0",
+  "skipFirmwareVersionCheck": true
+}

--- a/sdk/src/cameras/itof-camera/managers/camera_configuration.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_configuration.cpp
@@ -39,7 +39,8 @@ namespace aditof {
 CameraConfiguration::CameraConfiguration()
     : m_mipiOutputSpeed(-1), m_isdeskewEnabled(-1),
       m_enableTempCompensation(-1), m_enableEdgeConfidence(-1),
-      m_enableMetaDatainAB(-1), m_fsyncMode(-1), m_dropFirstFrame(true) {}
+      m_enableMetaDatainAB(-1), m_fsyncMode(-1), m_dropFirstFrame(true),
+      m_expectedFirmwareVersion(""), m_skipFirmwareVersionCheck(false) {}
 
 CameraConfiguration::~CameraConfiguration() {}
 
@@ -195,6 +196,28 @@ CameraConfiguration::loadDepthParamsFromJsonFile(const std::string &pathFile,
             }
         }
 
+        // Firmware version checking
+        json_object *expectedFirmwareVersion = NULL;
+        if (json_object_object_get_ex(config_json, "expectedFirmwareVersion",
+                                      &expectedFirmwareVersion)) {
+            if (json_object_is_type(expectedFirmwareVersion,
+                                    json_type_string)) {
+                const char *versionStr =
+                    json_object_get_string(expectedFirmwareVersion);
+                m_expectedFirmwareVersion = std::string(versionStr);
+            }
+        }
+
+        json_object *skipFirmwareVersionCheck = NULL;
+        if (json_object_object_get_ex(config_json, "skipFirmwareVersionCheck",
+                                      &skipFirmwareVersionCheck)) {
+            if (json_object_is_type(skipFirmwareVersionCheck,
+                                    json_type_boolean)) {
+                m_skipFirmwareVersionCheck =
+                    json_object_get_boolean(skipFirmwareVersionCheck);
+            }
+        }
+
         // Note: Mode iteration requires external available modes list
         // This will be provided by CameraItof via setDepthParamsForMode
         // For now, parse all numeric keys as modes
@@ -206,7 +229,9 @@ CameraConfiguration::loadDepthParamsFromJsonFile(const std::string &pathFile,
                 std::string(key) == "isdeskewEnabled" ||
                 std::string(key) == "enableTempCompensation" ||
                 std::string(key) == "enableEdgeConfidence" ||
-                std::string(key) == "dynamicModeSwitching") {
+                std::string(key) == "dynamicModeSwitching" ||
+                std::string(key) == "expectedFirmwareVersion" ||
+                std::string(key) == "skipFirmwareVersionCheck") {
                 continue;
             }
 
@@ -414,6 +439,62 @@ Status CameraConfiguration::restoreCachedDepthParams() {
         return Status::GENERIC_ERROR;
     }
     m_depth_params_map = m_depth_params_map_cache;
+    return Status::OK;
+}
+
+Status
+CameraConfiguration::loadFirmwareVersionConfig(const std::string &pathFile) {
+    using namespace std;
+
+    // Reset to defaults
+    m_expectedFirmwareVersion = "";
+    m_skipFirmwareVersionCheck = false;
+
+    // Check if file exists
+    ifstream configFile(pathFile);
+    if (!configFile.good()) {
+        LOG(WARNING) << "Firmware version config file not found: " << pathFile;
+        LOG(INFO) << "Firmware version check will be disabled";
+        return Status::OK; // Not an error - just means no firmware check
+    }
+    configFile.close();
+
+    // Read JSON file
+    json_object *firmware_config_json = json_object_from_file(pathFile.c_str());
+    if (!firmware_config_json) {
+        LOG(ERROR) << "Failed to parse firmware version config JSON: "
+                   << pathFile;
+        return Status::INVALID_ARGUMENT;
+    }
+
+    // Extract expectedFirmwareVersion
+    json_object *expectedFirmwareVersion = NULL;
+    if (json_object_object_get_ex(firmware_config_json,
+                                  "expectedFirmwareVersion",
+                                  &expectedFirmwareVersion)) {
+        if (json_object_is_type(expectedFirmwareVersion, json_type_string)) {
+            const char *versionStr =
+                json_object_get_string(expectedFirmwareVersion);
+            m_expectedFirmwareVersion = std::string(versionStr);
+            LOG(INFO) << "Loaded expected firmware version: "
+                      << m_expectedFirmwareVersion;
+        }
+    }
+
+    // Extract skipFirmwareVersionCheck
+    json_object *skipFirmwareVersionCheck = NULL;
+    if (json_object_object_get_ex(firmware_config_json,
+                                  "skipFirmwareVersionCheck",
+                                  &skipFirmwareVersionCheck)) {
+        if (json_object_is_type(skipFirmwareVersionCheck, json_type_boolean)) {
+            m_skipFirmwareVersionCheck =
+                json_object_get_boolean(skipFirmwareVersionCheck);
+            LOG(INFO) << "Skip firmware version check: "
+                      << (m_skipFirmwareVersionCheck ? "true" : "false");
+        }
+    }
+
+    json_object_put(firmware_config_json);
     return Status::OK;
 }
 

--- a/sdk/src/cameras/itof-camera/managers/camera_configuration.h
+++ b/sdk/src/cameras/itof-camera/managers/camera_configuration.h
@@ -164,6 +164,31 @@ class CameraConfiguration {
         m_iniKeyValPairs = pairs;
     }
 
+    std::string getExpectedFirmwareVersion() const {
+        return m_expectedFirmwareVersion;
+    }
+    void setExpectedFirmwareVersion(const std::string &version) {
+        m_expectedFirmwareVersion = version;
+    }
+
+    bool getSkipFirmwareVersionCheck() const {
+        return m_skipFirmwareVersionCheck;
+    }
+    void setSkipFirmwareVersionCheck(bool skip) {
+        m_skipFirmwareVersionCheck = skip;
+    }
+
+    /**
+     * @brief Loads firmware version configuration from a JSON file.
+     *
+     * Reads expectedFirmwareVersion and skipFirmwareVersionCheck fields from
+     * a dedicated firmware config file.
+     *
+     * @param[in] pathFile Path to firmware version config JSON file
+     * @return Status::OK on success, error codes on failure
+     */
+    Status loadFirmwareVersionConfig(const std::string &pathFile);
+
   private:
     /**
      * @brief Checks if a string is convertible to double.
@@ -187,6 +212,10 @@ class CameraConfiguration {
     bool m_dropFirstFrame;
     std::vector<std::pair<uint8_t, uint8_t>> m_configDmsSequence;
     std::map<std::string, std::string> m_iniKeyValPairs;
+
+    // Firmware version checking
+    std::string m_expectedFirmwareVersion;
+    bool m_skipFirmwareVersionCheck;
 };
 
 } // namespace aditof

--- a/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.cpp
@@ -33,8 +33,15 @@
 #include <aditof/adsd3500_hardware_interface.h>
 #include <aditof/camera_definitions.h>
 #include <aditof/log.h>
+#include <chrono>
 #include <cstring>
+#include <fstream>
+#include <thread>
 #include <unordered_map>
+#ifdef __linux__
+#include <limits.h>
+#include <unistd.h>
+#endif
 
 namespace aditof {
 
@@ -81,6 +88,47 @@ Status CameraInitializationManager::initializeOnlineMode(
             LOG(INFO) << "Auto-discovered configuration file: "
                       << effectiveConfigPath;
         }
+    }
+
+    // Load firmware version configuration from dedicated file
+    // Priority: 1) Build directory (shared by all examples)
+    //           2) System installation path
+    std::string fwConfigPath = "";
+
+#ifdef __linux__
+    // Try to find build directory by going up from binary location
+    char binaryPath[PATH_MAX];
+    ssize_t len =
+        readlink("/proc/self/exe", binaryPath, sizeof(binaryPath) - 1);
+    if (len != -1) {
+        binaryPath[len] = '\0';
+        std::string binPath(binaryPath);
+
+        // Navigate up to find build directory
+        // Typical path: build/examples/first-frame/first-frame
+        // We want: build/firmware_version_config.json
+        size_t examplesPos = binPath.find("/examples/");
+        if (examplesPos != std::string::npos) {
+            std::string buildDir = binPath.substr(0, examplesPos);
+            std::string buildFwConfigPath =
+                buildDir + "/firmware_version_config.json";
+            std::ifstream testFile(buildFwConfigPath);
+            if (testFile.good()) {
+                fwConfigPath = buildFwConfigPath;
+                testFile.close();
+            }
+        }
+    }
+#endif
+
+    // Fallback to system installation path
+    if (fwConfigPath.empty()) {
+        fwConfigPath = "/usr/local/share/aditof/firmware_version_config.json";
+    }
+
+    status = m_config->loadFirmwareVersionConfig(fwConfigPath);
+    if (status != Status::OK && status != Status::INVALID_ARGUMENT) {
+        LOG(WARNING) << "Could not load firmware version config, continuing...";
     }
 
     // Open sensor hardware interface
@@ -131,6 +179,35 @@ Status CameraInitializationManager::initializeOnlineMode(
         LOG(INFO) << "Current adsd3500 firmware git hash is: " << fwHash;
     }
     adsd3500FwVersion = {fwVersion, fwHash};
+
+    // Check firmware version against expected version from JSON config
+    std::string expectedFwVersion = m_config->getExpectedFirmwareVersion();
+    bool skipFwCheck = m_config->getSkipFirmwareVersionCheck();
+
+    if (!expectedFwVersion.empty() && !skipFwCheck && fwVersion != "unknown") {
+        if (fwVersion != expectedFwVersion) {
+            LOG(WARNING) << "Firmware version mismatch!";
+            LOG(WARNING) << "  Expected: " << expectedFwVersion;
+            LOG(WARNING) << "  Actual:   " << fwVersion;
+            LOG(WARNING) << "Delaying 10 seconds before proceeding...";
+            LOG(INFO)
+                << "To skip this delay, add \"skipFirmwareVersionCheck\": true "
+                   "to your JSON config";
+
+            // 10-second delay with countdown
+            for (int i = 10; i > 0; i--) {
+                LOG(INFO) << "Waiting... " << i << " seconds remaining";
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+
+            LOG(INFO)
+                << "Continuing initialization with mismatched firmware version";
+        } else {
+            LOG(INFO) << "Firmware version matches expected version";
+        }
+    } else if (!expectedFwVersion.empty() && skipFwCheck) {
+        LOG(INFO) << "Firmware version check skipped per JSON config override";
+    }
 
     // Load CCB data if any mode needs non-ISP processing
     status = loadCCBDataIfNeeded(availableModes);

--- a/sdk/src/connections/target/adsd3500/adsd3500_chip_config_manager.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_chip_config_manager.cpp
@@ -209,7 +209,8 @@ aditof::Status Adsd3500ChipConfigManager::discoverChipCapabilities() {
         // Parse imager type with revision adjustment
         uint8_t imager_version = (readValue & ADSD3500_CHIP_INFO_IMAGER_MASK) >>
                                  ADSD3500_CHIP_INFO_IMAGER_SHIFT;
-        uint8_t revision_ver = ccb_version & ADSD3500_CHIP_INFO_REVISION_MASK;
+        uint8_t revision_ver =
+            imager_version & ADSD3500_CHIP_INFO_REVISION_MASK;
         imager_version = (revision_ver == ADSD3500_CHIP_INFO_REVISION_ADJUST)
                              ? (imager_version + revision_ver)
                              : imager_version;

--- a/sdk/src/connections/target/adsd3500/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_sensor.cpp
@@ -1220,16 +1220,12 @@ aditof::Status Adsd3500Sensor::setControl(const std::string &control,
             // Update runtime bit config so setMode/setVideoProperties uses correct value
             if (modeNum < m_bitsInAB.size()) {
                 m_bitsInAB[modeNum] = actualBits;
-                LOG(INFO) << "Runtime config: m_bitsInAB[" << (int)modeNum
-                          << "] = " << (int)actualBits;
             }
         } else if (control == "confidenceBits") {
             m_modeSelector.setControl("confBits", convertor[bitIndex]);
             // Update runtime bit config so setMode/setVideoProperties uses correct value
             if (modeNum < m_bitsInConf.size()) {
                 m_bitsInConf[modeNum] = actualBits;
-                LOG(INFO) << "Runtime config: m_bitsInConf[" << (int)modeNum
-                          << "] = " << (int)actualBits;
             }
         }
     }


### PR DESCRIPTION
Implement firmware version checking during camera initialization with 10-second countdown on mismatch. Configuration via shared build/firmware_version_config.json file with expectedFirmwareVersion and skipFirmwareVersionCheck fields. Auto-updates on source config changes. SDK logs mismatch warnings and allows override via JSON skip flag.