### PR TITLE
feat(sdk): implement XYZ table rotation and offline recording support

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -62,6 +62,104 @@
 #include <cassert>
 
 /**
+ * @brief Rotates XYZ lookup tables 90° clockwise for portrait VGA orientation.
+ *
+ * Performs an in-place 90° clockwise rotation of the X, Y, Z coefficient tables
+ * used for 3D pointcloud generation. Also rotates the 3D coordinate system:
+ * (x, y, z) → (-y, x, z) to maintain correct world-space alignment after rotation.
+ *
+ * This operation is required when the imager is mounted in portrait orientation
+ * (e.g., ADTF3066 in VGA mode) but pointcloud output should match landscape
+ * sensor calibration.
+ *
+ * Uses cache-blocking optimization (64×64 tiles) and fused plane processing to
+ * maximize L1 cache efficiency, similar to buffer_processor frame rotation.
+ *
+ * @param[in,out] p_x_table Pointer to X coefficient table
+ * @param[in,out] p_y_table Pointer to Y coefficient table
+ * @param[in,out] p_z_table Pointer to Z coefficient table
+ * @param[in] width Original frame width (number of columns before rotation)
+ * @param[in] height Original frame height (number of rows before rotation)
+ */
+void rotateXYZTables(const float **p_x_table, const float **p_y_table,
+                     const float **p_z_table, uint32_t width, uint32_t height) {
+    if (!p_x_table || !p_y_table || !p_z_table || !*p_x_table || !*p_y_table ||
+        !*p_z_table) {
+        return;
+    }
+
+    // Allocate rotated tables
+    float *x_rot = (float *)calloc(width * height, sizeof(float));
+    float *y_rot = (float *)calloc(width * height, sizeof(float));
+    float *z_rot = (float *)calloc(width * height, sizeof(float));
+
+    if (!x_rot || !y_rot || !z_rot) {
+        free(x_rot);
+        free(y_rot);
+        free(z_rot);
+        return;
+    }
+
+    // Cache-blocking: Process all 3 planes (X, Y, Z) together in one pass
+    // blkX 16KB + blkY 16KB + blkZ 16KB = 48KB < L1D 64KB → stays in cache
+    constexpr uint32_t T = 64;
+    const float *__restrict__ src_x = *p_x_table;
+    const float *__restrict__ src_y = *p_y_table;
+    const float *__restrict__ src_z = *p_z_table;
+    float *__restrict__ dst_x = x_rot;
+    float *__restrict__ dst_y = y_rot;
+    float *__restrict__ dst_z = z_rot;
+
+    // Process in 64×64 tiles for cache efficiency
+    // Rotate 90° CW: original(r,c) -> rotated(c, H-1-r)
+    // Also rotate 3D coordinates: (x,y,z) -> (-y,x,z)
+    float blkX[T][T], blkY[T][T], blkZ[T][T];
+
+    for (uint32_t r0 = 0; r0 < height; r0 += T) {
+        for (uint32_t c0 = 0; c0 < width; c0 += T) {
+            // Load tile from all 3 planes
+            uint32_t rEnd = (r0 + T < height) ? T : (height - r0);
+            uint32_t cEnd = (c0 + T < width) ? T : (width - c0);
+
+            for (uint32_t r = 0; r < rEnd; ++r) {
+                uint32_t srcRow = r0 + r;
+                for (uint32_t c = 0; c < cEnd; ++c) {
+                    uint32_t srcIdx = srcRow * width + (c0 + c);
+                    blkX[r][c] = src_x[srcIdx];
+                    blkY[r][c] = src_y[srcIdx];
+                    blkZ[r][c] = src_z[srcIdx];
+                }
+            }
+
+            // Rotate tile and apply coordinate transform
+            for (uint32_t r = 0; r < rEnd; ++r) {
+                uint32_t srcRow = r0 + r;
+                for (uint32_t c = 0; c < cEnd; ++c) {
+                    uint32_t srcCol = c0 + c;
+                    // 90° CW: (r,c) -> (c, H-1-r)
+                    uint32_t dstRow = srcCol;
+                    uint32_t dstCol = (height - 1) - srcRow;
+                    uint32_t dstIdx = dstRow * height + dstCol;
+
+                    // Coordinate transform: (x,y,z) -> (-y,x,z)
+                    dst_x[dstIdx] = -blkY[r][c];
+                    dst_y[dstIdx] = blkX[r][c];
+                    dst_z[dstIdx] = blkZ[r][c];
+                }
+            }
+        }
+    }
+
+    // Replace original tables
+    free((void *)*p_x_table);
+    free((void *)*p_y_table);
+    free((void *)*p_z_table);
+    *p_x_table = x_rot;
+    *p_y_table = y_rot;
+    *p_z_table = z_rot;
+}
+
+/**
  * @brief Constructor for CameraItof.
  *
  * Initializes a camera instance with a depth sensor interface and version information.
@@ -191,15 +289,17 @@ aditof::Status CameraItof::initialize(const std::string &configFilepath) {
         return Status::UNAVAILABLE;
     }
 
-    m_initConfigFilePath = configFilepath;
-
     if (!m_netLinkTest.empty()) {
         m_depthSensor->setControl("netlinktest", "1");
     }
 
+    std::string effectiveConfigPath;
     status = m_initManager->initializeOnlineMode(
         m_details, m_availableModes, m_availableSensorModeDetails, m_imagerType,
-        m_adsd3500FwGitHash, configFilepath);
+        m_adsd3500FwGitHash, configFilepath, effectiveConfigPath);
+
+    // Store the effective config path (auto-discovered or provided)
+    m_initConfigFilePath = effectiveConfigPath;
 
     if (status != Status::OK) {
         return status;
@@ -326,11 +426,21 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
     Status status = Status::OK;
 
     if (m_isOffline) {
-        status =
-            m_recordingMgr->loadPlaybackHeader(m_modeDetailsCache, m_details);
+        bool playbackRotation = false;
+        status = m_recordingMgr->loadPlaybackHeader(
+            m_modeDetailsCache, m_details, playbackRotation);
         if (status != Status::OK) {
             return status;
         }
+
+        // Use rotation state from recording file
+        m_rotationEnabled = playbackRotation;
+        LOG(INFO) << "[PLAYBACK] Using rotation state: "
+                  << (m_rotationEnabled ? "ENABLED" : "DISABLED");
+
+        // Set rotation control on sensor for playback
+        m_depthSensor->setControl("enableRotation",
+                                  m_rotationEnabled ? "1" : "0");
 
         m_pcmFrame = m_modeDetailsCache.isPCM;
         configureSensorModeDetails();
@@ -411,6 +521,9 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
                 LOG(INFO) << "Rotation using default: disabled";
             }
         }
+
+        // Store rotation state for XYZ computation and recording
+        m_rotationEnabled = (rotationValue == "1");
 
         // Apply the rotation control before setMode
         m_depthSensor->setControl("enableRotation", rotationValue);
@@ -665,6 +778,18 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
                 LOG(ERROR) << "Failed to generate the XYZ tables";
                 return Status::GENERIC_ERROR;
             }
+
+            // Rotate XYZ tables if rotation is enabled
+            if (m_rotationEnabled) {
+                LOG(INFO) << "Rotating XYZ tables 90° CW for mode "
+                          << (int)mode;
+                rotateXYZTables(&xyzTable.p_x_table, &xyzTable.p_y_table,
+                                &xyzTable.p_z_table,
+                                m_modeDetailsCache.baseResolutionWidth,
+                                m_modeDetailsCache.baseResolutionHeight);
+                m_calibrationMgr->setXYZTable(xyzTable);
+                LOG(INFO) << "XYZ tables rotated successfully";
+            }
         }
 
         // If a Dynamic Mode Switching sequences has been loaded from config file then configure ADSD3500
@@ -794,10 +919,18 @@ aditof::Status CameraItof::startRecording(std::string &filePath) {
         return aditof::Status::GENERIC_ERROR; // Invalid call
     }
 
-    return m_recordingMgr->startRecording(
+    aditof::Status status = m_recordingMgr->startRecording(
         filePath, m_cameraFps, m_details, m_modeDetailsCache,
         m_availableSensorModeDetails, m_depthEnabled, m_abEnabled,
-        m_confEnabled, m_xyzEnabled);
+        m_confEnabled, m_xyzEnabled, m_rotationEnabled);
+
+    // Rotation state is now stored in recording header via RecordingManager
+    if (status == aditof::Status::OK) {
+        LOG(INFO) << "[RECORDING] Started recording with rotation "
+                  << (m_rotationEnabled ? "ENABLED" : "DISABLED");
+    }
+
+    return status;
 }
 
 /**
@@ -1365,7 +1498,14 @@ aditof::Status
 CameraItof::loadDepthParamsFromJsonFile(const std::string &pathFile,
                                         const int16_t mode_in_use) {
     assert(!m_isOffline);
-    return m_config->loadDepthParamsFromJsonFile(pathFile, mode_in_use);
+    aditof::Status status =
+        m_config->loadDepthParamsFromJsonFile(pathFile, mode_in_use);
+    if (status == aditof::Status::OK) {
+        m_userJsonLoaded = true;
+        LOG(INFO) << "User JSON config loaded, enableRotation overrides will "
+                     "be respected";
+    }
+    return status;
 }
 
 /**

--- a/sdk/src/cameras/itof-camera/camera_itof.h
+++ b/sdk/src/cameras/itof-camera/camera_itof.h
@@ -38,11 +38,17 @@
 #include <aditof/adsd_errs.h>
 #include <aditof/camera.h>
 #include <aditof/depth_sensor_interface.h>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <unordered_map>
 
 #define NR_READADSD3500CCB 3
+
+// XYZ table rotation utility function
+// Rotates X, Y, Z lookup tables 90° clockwise for portrait orientation
+void rotateXYZTables(const float **p_x_table, const float **p_y_table,
+                     const float **p_z_table, uint32_t width, uint32_t height);
 
 namespace aditof {
 class Adsd3500Controller;
@@ -271,6 +277,8 @@ class CameraItof : public aditof::Camera {
     bool m_userJsonLoaded = false;
     aditof::ImagerType m_imagerType;
     bool m_dropFrameOnce; // Per-frame state; m_dropFirstFrame moved to m_config
+    bool m_rotationEnabled =
+        false; // True if XYZ tables and frames are rotated 90° CW
 };
 
 #endif // CAMERA_ITOF_H

--- a/sdk/src/cameras/itof-camera/managers/camera_frame_acquisition_manager.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_frame_acquisition_manager.cpp
@@ -91,7 +91,8 @@ Status CameraFrameAcquisitionManager::requestFrame(
     }
 
     // Step 7: Compute XYZ point cloud if enabled
-    status = computeXYZIfEnabled(frame, xyzEnabled, depthEnabled, modeDetails);
+    status = computeXYZIfEnabled(frame, xyzEnabled, depthEnabled, frameType,
+                                 modeDetails);
     if (status != Status::OK) {
         return status;
     }
@@ -195,7 +196,7 @@ Status CameraFrameAcquisitionManager::acquireRawFrame(uint16_t *dataLocation,
 
 Status CameraFrameAcquisitionManager::computeXYZIfEnabled(
     Frame *frame, bool xyzEnabled, bool depthEnabled,
-    const DepthSensorModeDetails &modeDetails) {
+    const FrameDetails &frameType, const DepthSensorModeDetails &modeDetails) {
 
     // XYZ computation requires depth and XYZ both enabled
     if (!xyzEnabled || !depthEnabled || !frame->haveDataType("xyz")) {
@@ -211,14 +212,15 @@ Status CameraFrameAcquisitionManager::computeXYZIfEnabled(
     if (getDepthStatus == Status::OK && getXYZStatus == Status::OK &&
         depthFrame != nullptr && xyzFrame != nullptr) {
 
-        // Get XYZ calibration table
+        // Get XYZ calibration table (already rotated if rotation enabled)
         XYZTable xyzTable = m_calibrationMgr->getXYZTable();
 
-        // Compute point cloud
+        // Compute point cloud using actual frame dimensions
+        // When rotation is enabled, both depth frame and XYZ tables are rotated,
+        // so we use the actual frame dimensions (which are swapped)
         Algorithms::ComputeXYZ(static_cast<const uint16_t *>(depthFrame),
                                &xyzTable, reinterpret_cast<int16_t *>(xyzFrame),
-                               modeDetails.baseResolutionHeight,
-                               modeDetails.baseResolutionWidth);
+                               frameType.height, frameType.width);
 
         return Status::OK;
     } else {

--- a/sdk/src/cameras/itof-camera/managers/camera_frame_acquisition_manager.h
+++ b/sdk/src/cameras/itof-camera/managers/camera_frame_acquisition_manager.h
@@ -163,11 +163,13 @@ class CameraFrameAcquisitionManager {
      * @brief Computes XYZ point cloud from depth frame.
      *
      * @param[in] frame Frame object containing depth data.
+     * @param[in] frameType Frame details with actual dimensions (swapped if rotation enabled).
      * @param[in] modeDetails Mode configuration for resolution info.
      *
      * @return Status::OK if XYZ computed successfully.
      */
     Status computeXYZIfEnabled(Frame *frame, bool xyzEnabled, bool depthEnabled,
+                               const FrameDetails &frameType,
                                const DepthSensorModeDetails &modeDetails);
 
     /**

--- a/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.cpp
@@ -73,7 +73,7 @@ Status CameraInitializationManager::initializeOnlineMode(
     std::vector<DepthSensorModeDetails> &availableSensorModeDetails,
     ImagerType &imagerType,
     std::pair<std::string, std::string> &adsd3500FwVersion,
-    const std::string &configFilepath) {
+    const std::string &configFilepath, std::string &effectiveConfigPath) {
 
     using namespace aditof;
     Status status = Status::OK;
@@ -81,7 +81,7 @@ Status CameraInitializationManager::initializeOnlineMode(
     LOG(INFO) << "Initializing camera: Online";
 
     // Auto-discover config file path
-    std::string effectiveConfigPath = configFilepath;
+    effectiveConfigPath = configFilepath;
     if (effectiveConfigPath.empty()) {
         effectiveConfigPath = m_config->autoDiscoverConfigFile();
         if (!effectiveConfigPath.empty()) {

--- a/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.h
+++ b/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.h
@@ -110,7 +110,7 @@ class CameraInitializationManager {
         std::vector<DepthSensorModeDetails> &availableSensorModeDetails,
         ImagerType &imagerType,
         std::pair<std::string, std::string> &adsd3500FwVersion,
-        const std::string &configFilepath);
+        const std::string &configFilepath, std::string &effectiveConfigPath);
 
     /**
      * @brief Initializes camera for offline (playback) operation.

--- a/sdk/src/cameras/itof-camera/managers/recording_manager.cpp
+++ b/sdk/src/cameras/itof-camera/managers/recording_manager.cpp
@@ -8,6 +8,11 @@
 #include "calibration_manager.h"
 #include "camera_configuration.h"
 
+// Forward declare rotateXYZTables to avoid circular dependency
+extern void rotateXYZTables(const float **p_x_table, const float **p_y_table,
+                            const float **p_z_table, uint32_t width,
+                            uint32_t height);
+
 #include "tofi/algorithms.h"
 #include <aditof/frame_definitions.h>
 #include <aditof/log.h>
@@ -31,7 +36,8 @@ Status RecordingManager::startRecording(
     std::string &filePath, uint16_t cameraFps, const CameraDetails &details,
     const DepthSensorModeDetails &modeDetailsCache,
     const std::vector<DepthSensorModeDetails> &availableModes,
-    bool depthEnabled, bool abEnabled, bool confEnabled, bool xyzEnabled) {
+    bool depthEnabled, bool abEnabled, bool confEnabled, bool xyzEnabled,
+    bool rotationEnabled) {
 
     // Reset frame counter
     m_offline_parameters.numberOfFrames = 0;
@@ -46,6 +52,11 @@ Status RecordingManager::startRecording(
 
     // Store metadata embedding flag
     m_offline_parameters.enableMetaDatainAB = m_config->getMetadataInAB();
+
+    // Store rotation state for playback
+    m_offline_parameters.rotationEnabled = rotationEnabled ? 1 : 0;
+    LOG(INFO) << "[RECORDING] Rotation state: "
+              << (rotationEnabled ? "ENABLED" : "DISABLED");
 
     // Copy mode details cache
     m_offline_parameters.modeDetailsCache.modeNumber =
@@ -109,8 +120,9 @@ Status RecordingManager::startRecording(
     }
 
     m_offline_parameters.details.mode = mode;
-    m_offline_parameters.details.width = (*modeIt).baseResolutionWidth;
-    m_offline_parameters.details.height = (*modeIt).baseResolutionHeight;
+    // Store actual frame dimensions (already swapped if rotation enabled)
+    m_offline_parameters.details.width = details.frameType.width;
+    m_offline_parameters.details.height = details.frameType.height;
     m_offline_parameters.details.totalCaptures = 1;
 
     LOG(INFO) << "[RECORDING] Building fDataDetails from frameContent...";
@@ -132,10 +144,10 @@ Status RecordingManager::startRecording(
             .type[sizeof(m_offline_parameters.fDataDetails[idx].type) - 1] =
             '\0';
 
-        m_offline_parameters.fDataDetails[idx].width =
-            modeDetailsCache.baseResolutionWidth;
+        // Use actual frame dimensions (already swapped if rotation enabled)
+        m_offline_parameters.fDataDetails[idx].width = details.frameType.width;
         m_offline_parameters.fDataDetails[idx].height =
-            modeDetailsCache.baseResolutionHeight;
+            details.frameType.height;
         m_offline_parameters.fDataDetails[idx].subelementSize =
             sizeof(uint16_t);
         m_offline_parameters.fDataDetails[idx].subelementsPerElement = 1;
@@ -207,7 +219,8 @@ Status RecordingManager::setPlaybackFile(std::string &filePath) {
 
 Status
 RecordingManager::loadPlaybackHeader(DepthSensorModeDetails &modeDetailsCache,
-                                     CameraDetails &details) {
+                                     CameraDetails &details,
+                                     bool &rotationEnabled) {
 
     // Clear and read header from playback file
     memset((void *)&m_offline_parameters, 0, sizeof(m_offline_parameters));
@@ -272,6 +285,11 @@ RecordingManager::loadPlaybackHeader(DepthSensorModeDetails &modeDetailsCache,
     details.mode = m_offline_parameters.details.mode;
     details.frameType.width = m_offline_parameters.details.width;
     details.frameType.height = m_offline_parameters.details.height;
+
+    // Return rotation state from recording
+    rotationEnabled = (m_offline_parameters.rotationEnabled != 0);
+    LOG(INFO) << "[PLAYBACK] Rotation state from recording: "
+              << (rotationEnabled ? "ENABLED" : "DISABLED");
     details.frameType.totalCaptures =
         m_offline_parameters.details.totalCaptures;
     details.frameType.dataDetails.clear();
@@ -313,6 +331,17 @@ RecordingManager::loadPlaybackHeader(DepthSensorModeDetails &modeDetailsCache,
         !xyzTable.p_z_table) {
         LOG(ERROR) << "Failed to generate the XYZ tables";
         return Status::GENERIC_ERROR;
+    }
+
+    // Rotate XYZ tables if recording was made with rotation enabled
+    if (rotationEnabled) {
+        LOG(INFO) << "[PLAYBACK] Rotating XYZ tables 90° CW to match recording";
+        rotateXYZTables(&xyzTable.p_x_table, &xyzTable.p_y_table,
+                        &xyzTable.p_z_table,
+                        modeDetailsCache.baseResolutionWidth,
+                        modeDetailsCache.baseResolutionHeight);
+        m_calibrationMgr->setXYZTable(xyzTable);
+        LOG(INFO) << "[PLAYBACK] XYZ tables rotated successfully";
     }
 
     return Status::OK;

--- a/sdk/src/cameras/itof-camera/managers/recording_manager.h
+++ b/sdk/src/cameras/itof-camera/managers/recording_manager.h
@@ -49,13 +49,16 @@ class RecordingManager {
      * @param abEnabled AB frame recording enabled
      * @param confEnabled Confidence frame recording enabled
      * @param xyzEnabled XYZ frame recording enabled
+     * @param rotationEnabled True if frames/XYZ tables are rotated 90° CW
      * @return Status::OK on success
      */
-    Status startRecording(
-        std::string &filePath, uint16_t cameraFps, const CameraDetails &details,
-        const DepthSensorModeDetails &modeDetailsCache,
-        const std::vector<DepthSensorModeDetails> &availableModes,
-        bool depthEnabled, bool abEnabled, bool confEnabled, bool xyzEnabled);
+    Status
+    startRecording(std::string &filePath, uint16_t cameraFps,
+                   const CameraDetails &details,
+                   const DepthSensorModeDetails &modeDetailsCache,
+                   const std::vector<DepthSensorModeDetails> &availableModes,
+                   bool depthEnabled, bool abEnabled, bool confEnabled,
+                   bool xyzEnabled, bool rotationEnabled);
 
     /**
      * @brief Stops recording and closes the recording file.
@@ -75,10 +78,11 @@ class RecordingManager {
      * @brief Loads recording header and initializes playback state.
      * @param[out] modeDetailsCache Mode details loaded from file
      * @param[out] details Camera details loaded from file
+     * @param[out] rotationEnabled True if recording was made with rotation enabled
      * @return Status::OK on success
      */
     Status loadPlaybackHeader(DepthSensorModeDetails &modeDetailsCache,
-                              CameraDetails &details);
+                              CameraDetails &details, bool &rotationEnabled);
 
     /**
      * @brief Gets the number of frames in the playback file.
@@ -107,6 +111,8 @@ class RecordingManager {
         const uint32_t formatVersion = 0x00000001;
         uint16_t frameRate;
         uint16_t enableMetaDatainAB;
+        uint32_t
+            rotationEnabled; // 1 if XYZ tables and frames are rotated 90° CW, 0 otherwise
         TofiXYZDealiasData dealias;
         struct {
             uint32_t mode;


### PR DESCRIPTION
Add 90° rotation for XYZ tables/pointcloud with recording/playback support. Fixes ADTF3066 portrait orientation and enables user config overrides.

- Add rotateXYZTables() with cache-blocking optimization
- Add m_rotationEnabled flag and rotation logic (ADTF3066 default + user override)
- Fix m_userJsonLoaded flag and config auto-discovery
- Store rotation state and actual dimensions in recording header
- Rotate XYZ tables during playback when needed
- Fix XYZ computation to use actual frame dimensions

Follows rel-7.0.0-a.1 reference implementation.