### PR TITLE
Adcam build fix 7 1 0

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -319,7 +319,7 @@ endif()
 
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME} PUBLIC
+    target_compile_options(${PROJECT_NAME} PRIVATE
             -Wall
             -Wno-unknown-pragmas
             -Werror=return-type

--- a/sdk/include/aditof/version-kit.h
+++ b/sdk/include/aditof/version-kit.h
@@ -34,8 +34,8 @@
 
 #include <string>
 
-#define ADCAM_API_VERSION_MAJOR "0"
-#define ADCAM_API_VERSION_MINOR "2"
+#define ADCAM_API_VERSION_MAJOR "1"
+#define ADCAM_API_VERSION_MINOR "0"
 #define ADCAM_API_VERSION_PATCH "0"
 #define ADCAM_API_VERSION                                                     \
     (ADCAM_API_VERSION_MAJOR "." ADCAM_API_VERSION_MINOR                     \


### PR DESCRIPTION
1. fix(build): change GCC warning flags from PUBLIC to PRIVATE to prevent NVCC compilation errors
2. chore(version): bump ADCAM API version from 0.2.0 to 1.0.0