### PR TITLE
Adcam build fix 7 1 0

### DIFF
--- a/.github/workflows/automerge_libaditof_main_to_dev.yml
+++ b/.github/workflows/automerge_libaditof_main_to_dev.yml
@@ -3,7 +3,7 @@ name: Auto Merge rel-* to dev branch (with submodules)
 on:
   push:
     branches:
-      - rel-7.0.0-a.1
+      - rel-7.1.0
 
 jobs:
   merge:
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout rel* branch
         uses: actions/checkout@v3
         with:
-          ref: rel-7.0.0-a.1
+          ref: rel-7.1.0
           fetch-depth: 0
           submodules: true
           persist-credentials: false
@@ -24,28 +24,28 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           
-      - name: Fetch dev-7.0.0-a-1 branch
+      - name: Fetch dev-7.1.0 branch
         run: |
-          git fetch origin dev-7.0.0-a-1 || echo "dev-7.0.0-a-1 does not exist yet"
+          git fetch origin dev-7.1.0 || echo "dev-7.1.0 does not exist yet"
 
-      - name: Checkout or create dev-7.0.0-a-1
+      - name: Checkout or create dev-7.1.0
         run: |
-          if git show-ref --verify --quiet refs/remotes/origin/dev-7.0.0-a-1; then
-            git checkout -B dev-7.0.0-a-1 origin/dev-7.0.0-a-1
+          if git show-ref --verify --quiet refs/remotes/origin/dev-7.1.0; then
+            git checkout -b dev-7.1.0 origin/dev-7.1.0
           else
-            git checkout -b dev-7.0.0-a-1
+            git checkout -b dev-7.1.0
           fi      
 
-      - name: Force replace dev branch with rel-7.0.0-a.1 branch contents (including submodules)
+      - name: Force replace dev branch with rel-7.1.0 branch contents (including submodules)
         run: |
           set -e
-          git reset --hard origin/rel-7.0.0-a.1
+          git reset --hard origin/rel-7.1.0
           git submodule update --init --recursive
           git add .
-          git commit -m "Force sync dev branch with rel-7.0.0-a.1 branch (including submodules)" || echo "No changes to commit"
+          git commit -m "Force sync dev branch with rel-7.1.0 branch (including submodules)" || echo "No changes to commit"
 
       - name: Push changes to dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git dev-7.0.0-a-1 --force
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git dev-7.1.0 --force

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,8 @@ endif()
 
 ############################### Version #######################################
 set(ADITOF_VERSION_MAJOR 7)
-set(ADITOF_VERSION_MINOR 0)
+set(ADITOF_VERSION_MINOR 1)
 set(ADITOF_VERSION_PATCH 0)
-set(ADITOF_VERSION_QUALITY a-1)
 
 set(VERSION "${ADITOF_VERSION_MAJOR}.${ADITOF_VERSION_MINOR}.${ADITOF_VERSION_PATCH}")
 

--- a/bindings/python/aditofpython.cpp
+++ b/bindings/python/aditofpython.cpp
@@ -104,6 +104,8 @@ PYBIND11_MODULE(aditofpython, m) {
                aditof::Adsd3500Status::INVALID_INI_UPDATE_IN_PCM_MODE)
         .value("Unsupported_Mode_INI_Read",
                aditof::Adsd3500Status::UNSUPPORTED_MODE_INI_READ)
+        .value("Second_Adsd3500_Boot_Failure",
+               aditof::Adsd3500Status::SECOND_ADSD3500_BOOT_FAILURE)
         .value("Imager_Stream_Off", aditof::Adsd3500Status::IMAGER_STREAM_OFF)
         .value("Unknown_Error_Id", aditof::Adsd3500Status::UNKNOWN_ERROR_ID);
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -319,7 +319,7 @@ endif()
 
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(${PROJECT_NAME} PUBLIC
+    target_compile_options(${PROJECT_NAME} PRIVATE
             -Wall
             -Wno-unknown-pragmas
             -Werror=return-type

--- a/sdk/include/aditof/status_definitions.h
+++ b/sdk/include/aditof/status_definitions.h
@@ -84,6 +84,7 @@ enum class Adsd3500Status {
     FLASH_STATUS_CHUNK_ALREADY_FOUND,  //!< Flash status chunck already found
     INVALID_INI_UPDATE_IN_PCM_MODE,    //!< Invalid INI update in PCM mode
     UNSUPPORTED_MODE_INI_READ,         //!< Unsupported mode INI read
+    SECOND_ADSD3500_BOOT_FAILURE,      //!< Second ADSD3500 boot failure
     IMAGER_STREAM_OFF,                 //!< Stream off from imager
     UNKNOWN_ERROR_ID                   //!< Unknown ID read from ADSD3500
 };

--- a/sdk/include/aditof/version-kit.h
+++ b/sdk/include/aditof/version-kit.h
@@ -34,8 +34,8 @@
 
 #include <string>
 
-#define ADCAM_API_VERSION_MAJOR "0"
-#define ADCAM_API_VERSION_MINOR "2"
+#define ADCAM_API_VERSION_MAJOR "1"
+#define ADCAM_API_VERSION_MINOR "0"
 #define ADCAM_API_VERSION_PATCH "0"
 #define ADCAM_API_VERSION                                                     \
     (ADCAM_API_VERSION_MAJOR "." ADCAM_API_VERSION_MINOR                     \

--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -1474,7 +1474,7 @@ std::string CameraItof::autoDiscoverConfigFile() {
 aditof::Status
 CameraItof::saveDepthParamsToJsonFile(const std::string &savePathFile) {
     assert(!m_isOffline);
-    return m_config->saveDepthParamsToJsonFile(savePathFile);
+    return m_config->saveDepthParamsToJsonFile(savePathFile, m_rotationEnabled);
 }
 
 /**

--- a/sdk/src/cameras/itof-camera/managers/camera_configuration.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_configuration.cpp
@@ -312,8 +312,9 @@ CameraConfiguration::loadDepthParamsFromJsonFile(const std::string &pathFile,
     return status;
 }
 
-Status CameraConfiguration::saveDepthParamsToJsonFile(
-    const std::string &savePathFile, bool rotationEnabled) {
+Status
+CameraConfiguration::saveDepthParamsToJsonFile(const std::string &savePathFile,
+                                               bool rotationEnabled) {
 
     Status status = Status::OK;
 

--- a/sdk/src/cameras/itof-camera/managers/camera_configuration.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_configuration.cpp
@@ -313,9 +313,16 @@ CameraConfiguration::loadDepthParamsFromJsonFile(const std::string &pathFile,
 }
 
 Status CameraConfiguration::saveDepthParamsToJsonFile(
-    const std::string &savePathFile) {
+    const std::string &savePathFile, bool rotationEnabled) {
 
     Status status = Status::OK;
+
+    // Apply current rotation state to all modes before saving
+    // This ensures enableRotation is consistent across all modes in the saved config
+    std::string rotationValue = rotationEnabled ? "1" : "0";
+    for (auto &modePair : m_depth_params_map) {
+        modePair.second["enableRotation"] = rotationValue;
+    }
 
     json_object *rootjson = json_object_new_object();
 

--- a/sdk/src/cameras/itof-camera/managers/camera_configuration.h
+++ b/sdk/src/cameras/itof-camera/managers/camera_configuration.h
@@ -83,7 +83,8 @@ class CameraConfiguration {
      * @param[in] savePathFile Path where JSON file should be written
      * @return Status::OK on success, error codes on failure
      */
-    Status saveDepthParamsToJsonFile(const std::string &savePathFile);
+    Status saveDepthParamsToJsonFile(const std::string &savePathFile,
+                                      bool rotationEnabled = false);
 
     /**
      * @brief Retrieves depth parameters for a specific mode.

--- a/sdk/src/cameras/itof-camera/managers/camera_configuration.h
+++ b/sdk/src/cameras/itof-camera/managers/camera_configuration.h
@@ -84,7 +84,7 @@ class CameraConfiguration {
      * @return Status::OK on success, error codes on failure
      */
     Status saveDepthParamsToJsonFile(const std::string &savePathFile,
-                                      bool rotationEnabled = false);
+                                     bool rotationEnabled = false);
 
     /**
      * @brief Retrieves depth parameters for a specific mode.

--- a/sdk/src/cameras/itof-camera/managers/camera_frame_acquisition_manager.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_frame_acquisition_manager.cpp
@@ -284,7 +284,7 @@ Status CameraFrameAcquisitionManager::extractOrGenerateMetadata(
     uint8_t abBitsPerPixel, uint8_t confBitsPerPixel) {
 
     // Try to extract metadata from AB frame header if enabled
-    if (m_config->getMetadataInAB() && abEnabled) {
+    if (m_config->getMetadataInAB() && abEnabled && frame->haveDataType("ab")) {
         uint16_t *abFrame = nullptr;
         Status status = frame->getData("ab", &abFrame);
         if (status != Status::OK || abFrame == nullptr) {

--- a/sdk/src/connections/target/adsd3500/adsd3500_chip_config_manager.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_chip_config_manager.cpp
@@ -429,9 +429,18 @@ aditof::Status Adsd3500ChipConfigManager::configureFrameContent(
 
     using namespace aditof;
 
-    // Allocate bit depth vectors based on number of modes
-    bitsInAB.resize(availableModes.size());
-    bitsInConf.resize(availableModes.size());
+    // Find maximum mode number to size bit depth vectors correctly
+    uint8_t maxModeNumber = 0;
+    for (const auto &mode : availableModes) {
+        if (mode.modeNumber > maxModeNumber) {
+            maxModeNumber = mode.modeNumber;
+        }
+    }
+
+    // Allocate bit depth vectors based on maximum mode number (not mode count)
+    // This allows direct indexing by modeNumber without out-of-bounds access
+    bitsInAB.resize(maxModeNumber + 1, 0);
+    bitsInConf.resize(maxModeNumber + 1, 0);
 
     // Configure frame content for each mode
     for (size_t i = 0; i < availableModes.size(); ++i) {

--- a/sdk/src/connections/target/adsd3500/adsd3500_interrupt_manager.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_interrupt_manager.cpp
@@ -67,7 +67,11 @@ Adsd3500InterruptManager::adsd3500InterruptHandler(int signalValue) {
     uint16_t statusRegister;
     aditof::Status status = aditof::Status::OK;
 
-    usleep(ADSD3500_STATUS_READ_DELAY_US);
+    if (m_skipNextInterrupt) {
+        LOG(INFO) << "Skipping status register read for expected interrupt.";
+        m_skipNextInterrupt = false;
+        return status;
+    }
 
     status = m_protocolManager->adsd3500_read_cmd(ADSD3500_REG_CHIP_STATUS,
                                                   &statusRegister);
@@ -206,6 +210,9 @@ Adsd3500InterruptManager::convertIdToAdsd3500Status(int status) {
 
     case 35:
         return Adsd3500Status::UNSUPPORTED_MODE_INI_READ;
+
+    case 38:
+        return Adsd3500Status::SECOND_ADSD3500_BOOT_FAILURE;
 
     case 41:
         return Adsd3500Status::IMAGER_STREAM_OFF;

--- a/sdk/src/connections/target/adsd3500/adsd3500_interrupt_manager.h
+++ b/sdk/src/connections/target/adsd3500/adsd3500_interrupt_manager.h
@@ -97,6 +97,16 @@ class Adsd3500InterruptManager {
      */
     static aditof::Adsd3500Status convertIdToAdsd3500Status(int status);
 
+    /**
+     * @brief Skips the status register read on the next interrupt.
+     *
+     * Call before triggering a reset or stream-off so the resulting interrupt
+     * is silently consumed without reading ADSD3500 status registers.
+     *
+     * @param value true to skip next interrupt, false otherwise
+     */
+    void setSkipNextInterrupt(bool value) { m_skipNextInterrupt = value; }
+
   private:
     Adsd3500ProtocolManager
         *m_protocolManager;     ///< Protocol manager for status reads
@@ -104,7 +114,8 @@ class Adsd3500InterruptManager {
     int &m_imagerStatus;        ///< Reference to imager status
     bool &m_interruptAvailable; ///< Reference to interrupt available flag
     std::unordered_map<void *, aditof::SensorInterruptCallback>
-        &m_interruptCallbackMap; ///< Reference to interrupt callback map
+        &m_interruptCallbackMap;      ///< Reference to interrupt callback map
+    bool m_skipNextInterrupt = false; ///< Skip status read on next interrupt
 };
 
 #endif // ADSD3500_INTERRUPT_MANAGER_H

--- a/sdk/src/connections/target/adsd3500/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_sensor.cpp
@@ -627,6 +627,11 @@ aditof::Status Adsd3500Sensor::stop() {
             dev->started = false;
         }
     }
+
+    if (m_interruptManager) {
+        m_interruptManager->setSkipNextInterrupt(true);
+    }
+
     status = Adsd3500Sensor::adsd3500_getInterruptandReset();
     return status;
 }
@@ -1459,6 +1464,11 @@ aditof::Status Adsd3500Sensor::adsd3500_reset() {
     };
     status = adsd3500_register_interrupt_callback(cb);
     bool interruptsAvailable = (status == Status::OK);
+
+    // Signal interrupt handler to skip status read on first reset interrupt
+    if (m_interruptManager) {
+        m_interruptManager->setSkipNextInterrupt(true);
+    }
 
     // Use platform-specific reset logic
     auto &platform = aditof::platform::Platform::getInstance();

--- a/sdk/src/connections/target/frame_pipeline/buffer_processor.cpp
+++ b/sdk/src/connections/target/frame_pipeline/buffer_processor.cpp
@@ -110,6 +110,7 @@ BufferProcessor::BufferProcessor()
 
     m_outputFrameWidth = 0;
     m_outputFrameHeight = 0;
+    m_abFrameSize = 0;
     m_processorPropSet = false;
     m_vidPropSet = false;
     m_isRawBypassMode = false;
@@ -338,6 +339,7 @@ void BufferProcessor::calculateFrameSize(uint8_t &bitsInAB,
     }
 
     m_tofiBufferSize = depthSize + abSize + confSize;
+    m_abFrameSize = abSize;
 
     // For raw bypass, ensure ToFi buffer can hold the complete V4L2 buffer including NVIDIA alignment
     if (m_isRawBypassMode) {
@@ -358,9 +360,10 @@ void BufferProcessor::rotateEntireToFiBuffer(const uint16_t *src, uint16_t *dst,
     const uint32_t W = width;
     const uint32_t H = height;
     const uint32_t numPixels = W * H;
-    const uint32_t confOffset = numPixels * 2;
-    const bool hasAB = bufferSize > numPixels;
-    const bool hasConf = bufferSize > confOffset;
+    const uint32_t confOffset =
+        numPixels + m_abFrameSize; // actual layout: depth | [AB] | conf
+    const bool hasAB = m_abFrameSize > 0;
+    const bool hasConf = bufferSize > numPixels + m_abFrameSize;
     constexpr uint32_t T = 64;
 
     // Three explicit branch-free code paths so the hot inner loop contains no conditionals.

--- a/sdk/src/connections/target/frame_pipeline/buffer_processor.h
+++ b/sdk/src/connections/target/frame_pipeline/buffer_processor.h
@@ -230,6 +230,8 @@ class BufferProcessor : public aditof::V4lBufferAccessInterface,
 
     uint32_t m_rawFrameBufferSize;
     uint32_t m_tofiBufferSize;
+    uint32_t
+        m_abFrameSize; ///< AB plane size in uint16_t units (0 when bitsInAB=0)
     // Ping-pong output buffer for rotation: avoids final memcpy by swapping with
     // tofi_compute_io_buff after each frame so the rotated result is used directly.
     std::shared_ptr<uint16_t> m_rotationOutputBuffer;

--- a/sdk/src/status_definitions.cpp
+++ b/sdk/src/status_definitions.cpp
@@ -180,6 +180,9 @@ std::ostream &operator<<(std::ostream &os, aditof::Adsd3500Status status) {
     case Adsd3500Status::UNSUPPORTED_MODE_INI_READ:
         os << "Adsd3500Status::UNSUPPORTED_MODE_INI_READ";
         break;
+    case Adsd3500Status::SECOND_ADSD3500_BOOT_FAILURE:
+        os << "Adsd3500Status::SECOND_ADSD3500_BOOT_FAILURE";
+        break;
     case Adsd3500Status::IMAGER_STREAM_OFF:
         os << "Adsd3500Status::IMAGER_STREAM_OFF";
         break;


### PR DESCRIPTION
1. fix(build): change GCC warning flags from PUBLIC to PRIVATE to prevent NVCC compilation errors
2. chore(version): bump ADCAM API version from 0.2.0 to 1.0.0