### PR TITLE
fix(sdk): populate missing getDetails() fields for Python/C++ callers

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -645,6 +645,7 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
         m_details.frameType.width = reportedWidth;
         m_details.frameType.height = reportedHeight;
         m_details.frameType.totalCaptures = 1;
+        m_details.frameType.cameraMode = std::to_string(mode);
         m_details.frameType.dataDetails.clear();
         for (const auto &item : m_modeDetailsCache.frameContent) {
             if (item == "xyz" && !m_xyzEnabled) {
@@ -677,6 +678,19 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
                                       fDataDetails.subelementsPerElement;
 
             m_details.frameType.dataDetails.emplace_back(fDataDetails);
+        }
+
+        // Build frameType.type as "_"-joined channel names (e.g. "depth_conf_xyz")
+        // so callers can identify active channels from getDetails() without
+        // iterating dataDetails.
+        {
+            std::string ftype;
+            for (const auto &d : m_details.frameType.dataDetails) {
+                if (d.type == "metadata") continue;
+                if (!ftype.empty()) ftype += '_';
+                ftype += d.type;
+            }
+            m_details.frameType.type = ftype;
         }
 
         // We want computed frames (Depth & AB). Tell target to initialize depth compute

--- a/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.cpp
+++ b/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.cpp
@@ -265,6 +265,7 @@ Status CameraInitializationManager::initializeOnlineMode(
     status = readSerialNumber(serialNumber);
     if (status == Status::OK) {
         LOG(INFO) << "Module serial number: " << serialNumber;
+        cameraDetails.serialNumber = serialNumber;
     } else if (status == Status::UNAVAILABLE) {
         LOG(INFO) << "Serial read is not supported in this firmware!";
     } else {


### PR DESCRIPTION
camera_initialization_manager.cpp:
- Store serialNumber in cameraDetails so camera.getDetails() exposes it. Previously readSerialNumber() read and logged the value but never saved it to the CameraDetails struct.

camera_itof.cpp (setMode):
- Set frameType.cameraMode to the mode number string (e.g. "0", "2").
- Set frameType.type to a '_'-joined list of active channels (e.g. "depth_conf_xyz") built after the dataDetails loop, so callers can identify enabled frame types without iterating dataDetails.

Both fields were defined in FrameDetails / CameraDetails and exposed in the Python pybind11 bindings but were never assigned, causing empty strings to be returned.