### PR TITLE
fix(sdk): restore MIPI/deskew and reset chip on camera stop for mode …

### DIFF
--- a/sdk/src/cameras/itof-camera/camera_itof.cpp
+++ b/sdk/src/cameras/itof-camera/camera_itof.cpp
@@ -370,6 +370,25 @@ aditof::Status CameraItof::stop() {
 
     m_devStreaming = false;
 
+    // After stopping the stream, perform a chip GPIO reset and re-apply
+    // hardware configuration (MIPI output speed, deskew).  The ADSD3500
+    // clears these transport registers during its internal ISP reset on
+    // mode switch.  Resetting here leaves the chip in the same clean state
+    // as after initialize(), so the next setMode() + start() sequence
+    // mirrors the first-run path and delivers frames correctly.
+    if (!m_isOffline && m_adsd3500Hardware) {
+        aditof::Status resetStatus = m_adsd3500Hardware->adsd3500_reset();
+        if (resetStatus != aditof::Status::OK) {
+            LOG(WARNING) << "stop: chip GPIO reset failed (non-fatal)";
+        } else {
+            resetStatus = m_initManager->applyHardwareConfiguration();
+            if (resetStatus != aditof::Status::OK) {
+                LOG(WARNING) << "stop: failed to re-apply hardware config "
+                                "after reset (non-fatal)";
+            }
+        }
+    }
+
     return status;
 }
 
@@ -446,6 +465,19 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
         configureSensorModeDetails();
 
     } else {
+
+        // Ensure the camera is stopped before reconfiguring the chip.
+        // sensor::setMode() would call sensor::stop() internally, but
+        // camera_itof::stop() must run first so the GPIO reset and
+        // hardware configuration re-application happen before CTRL_SET_MODE.
+        if (m_devStreaming) {
+            status = stop();
+            if (status != Status::OK) {
+                LOG(ERROR)
+                    << "setMode: failed to stop camera before mode switch";
+                return status;
+            }
+        }
 
         auto modeIt = std::find_if(m_availableSensorModeDetails.begin(),
                                    m_availableSensorModeDetails.end(),
@@ -686,8 +718,10 @@ aditof::Status CameraItof::setMode(const uint8_t &mode) {
         {
             std::string ftype;
             for (const auto &d : m_details.frameType.dataDetails) {
-                if (d.type == "metadata") continue;
-                if (!ftype.empty()) ftype += '_';
+                if (d.type == "metadata")
+                    continue;
+                if (!ftype.empty())
+                    ftype += '_';
                 ftype += d.type;
             }
             m_details.frameType.type = ftype;

--- a/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.h
+++ b/sdk/src/cameras/itof-camera/managers/camera_initialization_manager.h
@@ -122,6 +122,19 @@ class CameraInitializationManager {
      */
     aditof::Status initializeOfflineMode();
 
+    /**
+     * @brief Re-applies hardware configuration (MIPI, deskew, etc.) to the chip.
+     *
+     * The ADSD3500 resets its transport registers (MIPI output speed, deskew)
+     * during internal ISP reconfiguration on mode switch.  Call this after a
+     * chip GPIO reset and before CTRL_SET_MODE to restore settings to the same
+     * state as after initialize().
+     *
+     * @return Status::OK if all configurations applied successfully
+     * @return Status::GENERIC_ERROR on configuration failure
+     */
+    aditof::Status applyHardwareConfiguration();
+
   private:
     /**
      * @brief Opens the depth sensor hardware interface.
@@ -190,21 +203,6 @@ class CameraInitializationManager {
      * @return Status::GENERIC_ERROR on CCB read failure (warning only, continues init)
      */
     aditof::Status loadCCBDataIfNeeded(const std::vector<uint8_t> &modes);
-
-    /**
-     * @brief Configures hardware settings (FSYNC, MIPI, deskew, temp compensation).
-     *
-     * Applies configuration values from JSON or platform defaults:
-     * - FSYNC toggle mode
-     * - MIPI output speed
-     * - Deskew enable/disable
-     * - Temperature compensation
-     * - Edge confidence
-     *
-     * @return Status::OK if all configurations applied successfully
-     * @return Status::GENERIC_ERROR on configuration failure
-     */
-    aditof::Status applyHardwareConfiguration();
 
     /**
      * @brief Reads firmware version from ADSD3500.


### PR DESCRIPTION
…switch

After camera::stop(), perform a GPIO reset of the ADSD3500 and re-apply hardware configuration (MIPI output speed, deskew).  Without this, the chip's internal ISP reconfiguration on mode switch (e.g. QMP→MP) clears those transport registers, leaving the Tegra VI/CSI pipeline out of sync. The result was zero V4L2 frames after STREAMON on the second mode.

camera_itof::stop():
  - Call adsd3500_reset() after sensor::stop() completes
  - Call initManager->applyHardwareConfiguration() to restore MIPI + deskew
  - Both steps are non-fatal (log warning and continue on failure)

camera_itof::setMode():
  - If camera was streaming (m_devStreaming), call stop() explicitly before sensor::setMode() so the reset path always runs before CTRL_SET_MODE

CameraInitializationManager:
  - Promote applyHardwareConfiguration() from private to public so it can be called from camera_itof::stop()

Tested with test-mode-switch binary:
  QMP mode=2 (512x512): 5 frames OK
  MP  mode=0 (1024x1024): 5 frames OK after switch
  PASS: QMP->MP mode switch successful