### PR TITLE
fix: refresh stale videoDevs pointer on mode switch

### DIFF
--- a/sdk/src/connections/target/adsd3500/adsd3500_protocol_manager.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_protocol_manager.cpp
@@ -545,3 +545,7 @@ Adsd3500ProtocolManager::adsd3500_write_payload(uint8_t *payload,
 
     return status;
 }
+
+void Adsd3500ProtocolManager::updateVideoDevices(struct VideoDev *videoDevs) {
+    m_videoDevs = videoDevs;
+}

--- a/sdk/src/connections/target/adsd3500/adsd3500_protocol_manager.h
+++ b/sdk/src/connections/target/adsd3500/adsd3500_protocol_manager.h
@@ -132,6 +132,17 @@ class Adsd3500ProtocolManager {
     aditof::Status adsd3500_write_payload(uint8_t *payload,
                                           uint16_t payload_len);
 
+    /**
+     * @brief Updates the internal video device pointer after reallocation.
+     *
+     * Must be called whenever m_implData->videoDevs is reallocated (e.g. on
+     * mode switch) so that subsequent ioctl calls use the current file
+     * descriptors instead of the freed/stale ones.
+     *
+     * @param videoDevs Pointer to the newly allocated video device array
+     */
+    void updateVideoDevices(struct VideoDev *videoDevs);
+
   private:
     struct VideoDev *m_videoDevs; ///< Pointer to V4L2 video device array
     std::array<uint8_t, ADSD3500_CTRL_PACKET_SIZE>

--- a/sdk/src/connections/target/adsd3500/adsd3500_sensor.cpp
+++ b/sdk/src/connections/target/adsd3500/adsd3500_sensor.cpp
@@ -395,6 +395,10 @@ aditof::Status Adsd3500Sensor::open() {
         if (!m_protocolManager) {
             m_protocolManager = std::make_unique<Adsd3500ProtocolManager>(
                 m_implData->videoDevs, m_implData->ctrlBuf, m_adsd3500_mutex);
+        } else {
+            // videoDevs was reallocated; update the protocol manager's pointer
+            // so it uses the current file descriptors instead of stale ones.
+            m_protocolManager->updateVideoDevices(m_implData->videoDevs);
         }
 
         // Initialize interrupt manager BEFORE reset (required for callback registration)
@@ -520,6 +524,11 @@ aditof::Status Adsd3500Sensor::open() {
     if (!m_bufferManager) {
         m_bufferManager = std::make_unique<V4L2BufferManager>(
             m_implData->videoDevs, m_implData->numVideoDevs);
+    } else {
+        // videoDevs was reallocated; update the buffer manager's pointer
+        // to prevent stale-pointer UB on getDeviceFileDescriptor().
+        m_bufferManager->updateVideoDevices(m_implData->videoDevs,
+                                            m_implData->numVideoDevs);
     }
 
     // Initialize INI configuration manager

--- a/sdk/src/connections/target/v4l2/v4l2_buffer_manager.cpp
+++ b/sdk/src/connections/target/v4l2/v4l2_buffer_manager.cpp
@@ -210,3 +210,9 @@ aditof::Status V4L2BufferManager::cleanupBuffers(struct VideoDev *dev) {
     LOG(INFO) << "Cleaned up video buffers for device";
     return Status::OK;
 }
+
+void V4L2BufferManager::updateVideoDevices(struct VideoDev *videoDevs,
+                                           uint8_t numVideoDevs) {
+    m_videoDevs = videoDevs;
+    m_numVideoDevs = numVideoDevs;
+}

--- a/sdk/src/connections/target/v4l2/v4l2_buffer_manager.h
+++ b/sdk/src/connections/target/v4l2/v4l2_buffer_manager.h
@@ -120,6 +120,18 @@ class V4L2BufferManager {
      */
     aditof::Status cleanupBuffers(struct VideoDev *dev = nullptr);
 
+    /**
+     * @brief Updates the internal video device pointer after reallocation.
+     *
+     * Must be called whenever m_implData->videoDevs is reallocated (e.g. on
+     * mode switch) so that getDeviceFileDescriptor() and other methods that
+     * use m_videoDevs[0] directly do not dereference a stale/freed pointer.
+     *
+     * @param videoDevs   Pointer to the newly allocated video device array
+     * @param numVideoDevs Number of devices in the array
+     */
+    void updateVideoDevices(struct VideoDev *videoDevs, uint8_t numVideoDevs);
+
   private:
     struct VideoDev *m_videoDevs; ///< Pointer to V4L2 video device array
     uint8_t m_numVideoDevs;       ///< Number of video devices


### PR DESCRIPTION
setMode() deletes and reallocates m_implData->videoDevs, but ProtocolManager and V4L2BufferManager held raw pointers to the old (freed) array. On the second open() call, ioctl commands used garbage file descriptors (e.g. 32766) causing EBADF failures.

Add updateVideoDevices() to both managers and call it from the else branches in open() so the pointers are refreshed whenever videoDevs is reallocated.

This bug did not manifest in data-collect because the single-threaded use caused the new allocation to land at the same heap address by coincidence. The tof-viewer's background threads prevent this.